### PR TITLE
Ensure review logs capture supplied review time

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -301,6 +301,7 @@ class DatabaseService {
     required Vocab vocab,
     required int grade,
     required int nextInterval,
+    DateTime? reviewedAt,
   }) async {
     if (vocab.id == null) {
       throw ArgumentError('Cannot add review log for vocab without an ID');
@@ -309,7 +310,7 @@ class DatabaseService {
     final db = await database;
     final log = ReviewLog(
       vocabId: vocab.id!,
-      reviewedAt: DateTime.now(),
+      reviewedAt: reviewedAt ?? DateTime.now(),
       grade: grade,
       intervalAfter: nextInterval,
     );

--- a/lib/services/srs_service.dart
+++ b/lib/services/srs_service.dart
@@ -59,13 +59,14 @@ class SrsService {
     vocab.lastReviewedAt = now;
     vocab.dueAt = _calculateDueDate(now, newInterval);
     vocab.updatedAt = now;
-    
+
     await db.updateVocabSrsData(vocab);
 
     await db.addReviewLog(
-      vocab: vocab, 
-      grade: grade, 
-      nextInterval: newInterval
+      vocab: vocab,
+      grade: grade,
+      nextInterval: newInterval,
+      reviewedAt: now,
     );
   }
   

--- a/test/services/srs_service_test.dart
+++ b/test/services/srs_service_test.dart
@@ -18,11 +18,13 @@ class MockDatabaseService extends DatabaseService {
     required Vocab vocab,
     required int grade,
     required int nextInterval,
+    DateTime? reviewedAt,
   }) async {
     return TestDatabaseService.addReviewLog(
       vocab: vocab,
       grade: grade,
       nextInterval: nextInterval,
+      reviewedAt: reviewedAt,
     );
   }
 }
@@ -359,6 +361,8 @@ void main() {
         expect(logs.length, equals(1));
         expect(logs.first.grade, equals(4));
         expect(logs.first.intervalAfter, equals(1));
+        expect(logs.first.reviewedAt.millisecondsSinceEpoch,
+            equals(originalTime.millisecondsSinceEpoch));
       });
 
       test('should handle multiple consecutive reviews', () async {

--- a/test/test_database_helper.dart
+++ b/test/test_database_helper.dart
@@ -346,6 +346,7 @@ class TestDatabaseService {
     required Vocab vocab,
     required int grade,
     required int nextInterval,
+    DateTime? reviewedAt,
   }) async {
     if (vocab.id == null) {
       throw ArgumentError('Cannot add review log for vocab without an ID');
@@ -354,7 +355,7 @@ class TestDatabaseService {
     final db = await database;
     final log = ReviewLog(
       vocabId: vocab.id!,
-      reviewedAt: DateTime.now(),
+      reviewedAt: reviewedAt ?? DateTime.now(),
       grade: grade,
       intervalAfter: nextInterval,
     );


### PR DESCRIPTION
## Summary
- Allow specifying review time when adding review logs
- Pass custom review time from SRS review flow
- Verify review logs honor provided timestamps

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68976f0457708332af02d6dc8faca278