### PR TITLE
Add basic grammar learning feature

### DIFF
--- a/assets/presets/grammar_n5.json
+++ b/assets/presets/grammar_n5.json
@@ -1,0 +1,4 @@
+[
+  {"title":"は","meaning":"trợ từ chỉ chủ đề","level":"N5","example":"私は学生です。"},
+  {"title":"が","meaning":"trợ từ chỉ chủ thể","level":"N5","example":"猫が好きです。"}
+]

--- a/lib/models/grammar.dart
+++ b/lib/models/grammar.dart
@@ -1,0 +1,31 @@
+class Grammar {
+  final String title;
+  final String meaning;
+  final String level;
+  final String? example;
+
+  Grammar({
+    required this.title,
+    required this.meaning,
+    required this.level,
+    this.example,
+  });
+
+  factory Grammar.fromMap(Map<String, dynamic> map) {
+    return Grammar(
+      title: map['title'] as String,
+      meaning: map['meaning'] as String,
+      level: map['level'] as String,
+      example: map['example'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'meaning': meaning,
+      'level': level,
+      if (example != null) 'example': example,
+    };
+  }
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -6,6 +6,7 @@ import 'ui/screens/add_edit_vocab_screen.dart';
 import 'ui/screens/flashcards_screen.dart';
 import 'ui/screens/quiz_screen.dart';
 import 'ui/screens/stats_screen.dart';
+import 'ui/screens/grammar_list_screen.dart';
 
 final router = GoRouter(routes: [
   GoRoute(path: '/', builder: (_, __) => const HomeScreen()),
@@ -19,5 +20,6 @@ final router = GoRouter(routes: [
   ),
   GoRoute(path: '/flash', builder: (_, __) => const FlashcardsScreen()),
   GoRoute(path: '/quiz', builder: (_, __) => const QuizScreen()),
+  GoRoute(path: '/grammar', builder: (_, __) => const GrammarListScreen()),
   GoRoute(path: '/stats', builder: (_, __) => const StatsScreen()),
 ]);

--- a/lib/ui/screens/grammar_list_screen.dart
+++ b/lib/ui/screens/grammar_list_screen.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import '../../models/grammar.dart';
+
+class GrammarListScreen extends StatefulWidget {
+  const GrammarListScreen({super.key});
+
+  @override
+  State<GrammarListScreen> createState() => _GrammarListScreenState();
+}
+
+class _GrammarListScreenState extends State<GrammarListScreen> {
+  List<Grammar>? _grammars;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final raw = await rootBundle.loadString('assets/presets/grammar_n5.json');
+      final list = jsonDecode(raw) as List;
+      _grammars =
+          list.map((e) => Grammar.fromMap(e as Map<String, dynamic>)).toList();
+    } catch (e) {
+      _error = e.toString();
+    }
+    if (mounted) {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Ngữ pháp')),
+        body: Center(child: Text('Lỗi: $_error')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ngữ pháp N5')),
+      body: ListView.builder(
+        itemCount: _grammars?.length ?? 0,
+        itemBuilder: (context, index) {
+          final g = _grammars![index];
+          return ListTile(
+            title: Text(
+              g.title,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(g.meaning),
+                if (g.example != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4.0),
+                    child: Text('Ví dụ: ${g.example}'),
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -13,6 +13,7 @@ class HomeScreen extends StatelessWidget {
       _HomeItem(Icons.add_circle, 'Thêm từ', '/add'),
       _HomeItem(Icons.style, 'Flashcards', '/flash'),
       _HomeItem(Icons.quiz, 'Trắc nghiệm', '/quiz'),
+      _HomeItem(Icons.menu_book, 'Ngữ pháp', '/grammar'),
       _HomeItem(Icons.auto_awesome, 'Thống kê & SRS', '/stats'),
     ];
 


### PR DESCRIPTION
## Summary
- add Grammar model and sample N5 grammar preset
- implement GrammarListScreen to display grammar rules from JSON
- expose new grammar section via home screen and router

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(failed: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68976f9b05f083328300cc719157f7b2