### PR TITLE
feat: allow preview review time

### DIFF
--- a/lib/services/srs_service.dart
+++ b/lib/services/srs_service.dart
@@ -112,26 +112,26 @@ class SrsService {
   
   /// Get the next suggested review interval without updating the vocab
   /// Useful for previewing what would happen with different grades
-  Map<String, dynamic> previewReview(Vocab vocab, int grade) {
-    if (grade < 0 || grade > 5) {
-      throw ArgumentError('Grade must be between 0 and 5, got: $grade');
+    Map<String, dynamic> previewReview(Vocab vocab, int grade, {DateTime? reviewTime}) {
+      if (grade < 0 || grade > 5) {
+        throw ArgumentError('Grade must be between 0 and 5, got: $grade');
+      }
+
+      final isPassing = grade >= passingGrade;
+      final newRepetitions = _calculateRepetitions(vocab.repetitions, isPassing);
+      final newEasiness = _calculateEasiness(vocab.easiness, grade);
+      final newInterval = _calculateInterval(newRepetitions, newEasiness, vocab.intervalDays, isPassing);
+      final newDueDate = _calculateDueDate(reviewTime ?? DateTime.now(), newInterval);
+
+      return {
+        'repetitions': newRepetitions,
+        'easiness': newEasiness,
+        'intervalDays': newInterval,
+        'dueAt': newDueDate,
+        'wasPromoted': isPassing && vocab.repetitions < newRepetitions,
+        'wasDemoted': !isPassing && vocab.repetitions > 0,
+      };
     }
-    
-    final isPassing = grade >= passingGrade;
-    final newRepetitions = _calculateRepetitions(vocab.repetitions, isPassing);
-    final newEasiness = _calculateEasiness(vocab.easiness, grade);
-    final newInterval = _calculateInterval(newRepetitions, newEasiness, vocab.intervalDays, isPassing);
-    final newDueDate = _calculateDueDate(DateTime.now(), newInterval);
-    
-    return {
-      'repetitions': newRepetitions,
-      'easiness': newEasiness,
-      'intervalDays': newInterval,
-      'dueAt': newDueDate,
-      'wasPromoted': isPassing && vocab.repetitions < newRepetitions,
-      'wasDemoted': !isPassing && vocab.repetitions > 0,
-    };
-  }
   
   /// Check if a vocab is due for review
   bool isDue(Vocab vocab, {DateTime? checkTime}) {

--- a/test/services/srs_service_test.dart
+++ b/test/services/srs_service_test.dart
@@ -199,7 +199,7 @@ void main() {
         final fixedTime = DateTime(2024, 1, 1, 12, 0, 0);
         final vocab = _createTestVocab();
         
-        final preview = srsService.previewReview(vocab, 4);
+        final preview = srsService.previewReview(vocab, 4, reviewTime: fixedTime);
         final expectedDueDate = fixedTime.add(Duration(days: preview['intervalDays']));
         
         // Allow for small time differences due to DateTime.now() calls


### PR DESCRIPTION
## Summary
- allow supplying custom review time when previewing SRS review
- update SRS service tests to use deterministic review time

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68976f1d99f88332a74b90998a94b575