### PR TITLE
Await vocab inserts during preset import

### DIFF
--- a/lib/services/preset_loader.dart
+++ b/lib/services/preset_loader.dart
@@ -12,7 +12,12 @@ class PresetLoader {
     final list = jsonDecode(raw) as List;
     var count = 0;
     for (final m in list) {
-      db.addVocab(term: m['term'], meaning: m['meaning'], level: m['level'], note: m['note']);
+      await db.addVocab(
+        term: m['term'],
+        meaning: m['meaning'],
+        level: m['level'],
+        note: m['note'],
+      );
       count++;
     }
     return count;


### PR DESCRIPTION
## Summary
- ensure preset vocab imports wait for each database insert

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68977162c9e08332b630e551f3e9d627