### PR TITLE
docs: update installation path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nihongo - Ứng dụng học từ vựng tiếng Nhật
+# Nihongo Flashcard - Ứng dụng học từ vựng tiếng Nhật
 
 Ứng dụng Flutter quản lý từ vựng tiếng Nhật với hệ thống SRS (Spaced Repetition System) và flashcards.
 
@@ -22,7 +22,7 @@
 ### 1. Clone repository
 ```bash
 git clone <repository-url>
-cd nihongo
+cd nihongo-flashcard
 ```
 
 ### 2. Cài đặt dependencies
@@ -97,7 +97,7 @@ flutter build apk
    - Device > Erase All Content and Settings
 
 3. **Reset app data (Android Emulator):**
-   - Settings > Apps > Nihongo > Storage > Clear Data
+   - Settings > Apps > Nihongo Flashcard > Storage > Clear Data
 
 ### Lỗi build iOS
 
@@ -191,7 +191,7 @@ Nếu gặp vấn đề, vui lòng:
 
 **Chúc bạn học tiếng Nhật vui vẻ! がんばって！** 🇯🇵
 
-# Nihongo MVP (Flutter + SQLite + SRS)
+# Nihongo Flashcard MVP (Flutter + SQLite + SRS)
 
 Ứng dụng học từ vựng tiếng Nhật: quản lý JLPT, flashcards, trắc nghiệm, thống kê + thuật toán SRS (SM-2 rút gọn).
 


### PR DESCRIPTION
## Summary
- update installation instructions to use `cd nihongo-flashcard`
- align remaining README references with new project name

## Testing
- `./test_app.sh` *(fails: flutter: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897715ebd4083329189a8e299af5e6e