### PR TITLE
test: add grammar model and screen tests

### DIFF
--- a/test/grammar_list_screen_test.dart
+++ b/test/grammar_list_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../lib/ui/screens/grammar_list_screen.dart';
+
+void main() {
+  testWidgets('GrammarListScreen loads and displays items', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: GrammarListScreen()));
+
+    // Wait for asset loading
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ngữ pháp N5'), findsOneWidget);
+    expect(find.text('は'), findsOneWidget);
+    expect(find.text('trợ từ chỉ chủ đề'), findsOneWidget);
+  });
+}

--- a/test/models/grammar_model_test.dart
+++ b/test/models/grammar_model_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../../lib/models/grammar.dart';
+
+void main() {
+  group('Grammar Model Tests', () {
+    test('creates Grammar with required fields', () {
+      final grammar = Grammar(
+        title: 'は',
+        meaning: 'trợ từ chỉ chủ đề',
+        level: 'N5',
+      );
+
+      expect(grammar.title, 'は');
+      expect(grammar.meaning, 'trợ từ chỉ chủ đề');
+      expect(grammar.level, 'N5');
+      expect(grammar.example, isNull);
+    });
+
+    test('creates Grammar with example', () {
+      final grammar = Grammar(
+        title: 'が',
+        meaning: 'trợ từ chỉ chủ thể',
+        level: 'N5',
+        example: '猫が好きです。',
+      );
+
+      expect(grammar.example, '猫が好きです。');
+    });
+
+    test('toMap includes non-null fields only', () {
+      final grammar = Grammar(
+        title: 'は',
+        meaning: 'trợ từ chỉ chủ đề',
+        level: 'N5',
+      );
+
+      final map = grammar.toMap();
+
+      expect(map['title'], 'は');
+      expect(map['meaning'], 'trợ từ chỉ chủ đề');
+      expect(map['level'], 'N5');
+      expect(map.containsKey('example'), isFalse);
+    });
+
+    test('fromMap creates valid Grammar', () {
+      final map = {
+        'title': 'が',
+        'meaning': 'trợ từ chỉ chủ thể',
+        'level': 'N5',
+        'example': '猫が好きです。',
+      };
+
+      final grammar = Grammar.fromMap(map);
+
+      expect(grammar.title, 'が');
+      expect(grammar.meaning, 'trợ từ chỉ chủ thể');
+      expect(grammar.level, 'N5');
+      expect(grammar.example, '猫が好きです。');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for Grammar model covering constructors and serialization
- add widget test to verify grammar list screen loads assets and displays items

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update >/tmp/apt.log` *(fails: repository 403 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68977434ad088332aa386ac90c729ba1