### PR TITLE
Add grammar quiz functionality

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -7,6 +7,7 @@ import 'ui/screens/flashcards_screen.dart';
 import 'ui/screens/quiz_screen.dart';
 import 'ui/screens/stats_screen.dart';
 import 'ui/screens/grammar_list_screen.dart';
+import 'ui/screens/grammar_quiz_screen.dart';
 
 final router = GoRouter(routes: [
   GoRoute(path: '/', builder: (_, __) => const HomeScreen()),
@@ -20,6 +21,7 @@ final router = GoRouter(routes: [
   ),
   GoRoute(path: '/flash', builder: (_, __) => const FlashcardsScreen()),
   GoRoute(path: '/quiz', builder: (_, __) => const QuizScreen()),
+  GoRoute(path: '/grammar-quiz', builder: (_, __) => const GrammarQuizScreen()),
   GoRoute(path: '/grammar', builder: (_, __) => const GrammarListScreen()),
   GoRoute(path: '/stats', builder: (_, __) => const StatsScreen()),
 ]);

--- a/lib/ui/screens/grammar_quiz_screen.dart
+++ b/lib/ui/screens/grammar_quiz_screen.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../../models/grammar.dart';
+
+class GrammarQuizScreen extends StatefulWidget {
+  const GrammarQuizScreen({super.key});
+
+  @override
+  State<GrammarQuizScreen> createState() => _GrammarQuizScreenState();
+}
+
+class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
+  List<Grammar> pool = [];
+  int qIndex = 0;
+  int correct = 0;
+  List<Grammar> options = [];
+  Grammar? current;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final raw =
+          await rootBundle.loadString('assets/presets/grammar_n5.json');
+      final list = jsonDecode(raw) as List;
+      pool =
+          list.map((e) => Grammar.fromMap(e as Map<String, dynamic>)).toList();
+      _nextQ();
+      setState(() {});
+    } catch (e) {
+      // ignore: avoid_print
+      print('Error loading grammar: $e');
+    }
+  }
+
+  void _nextQ() {
+    if (pool.isEmpty) return;
+    pool.shuffle();
+    current = pool.first;
+    final rng = Random();
+    final distractors = List<Grammar>.from(pool)..remove(current);
+    distractors.shuffle(rng);
+    final optionCount = min(4, pool.length);
+    options = ([current!] + distractors.take(optionCount - 1).toList())
+      ..shuffle(rng);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (current == null || options.isEmpty) {
+      return Scaffold(
+          appBar: AppBar(title: const Text('Trắc nghiệm Ngữ pháp')),
+          body: const Center(child: Text('Chưa đủ dữ liệu.')));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Trắc nghiệm Ngữ pháp')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Câu ${qIndex + 1}',
+                style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 8),
+            Card(
+                child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Text(current!.title,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.displaySmall),
+            )),
+            const SizedBox(height: 16),
+            for (final o in options)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: ElevatedButton(
+                  onPressed: () {
+                    final ok = o.title == current!.title;
+                    if (ok) correct++;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content:
+                            Text(ok ? 'Đúng!' : 'Sai: ${current!.meaning}'),
+                      ),
+                    );
+                    setState(() {
+                      qIndex++;
+                      _nextQ();
+                    });
+                  },
+                  child: Text(o.meaning),
+                ),
+              ),
+            const Spacer(),
+            Text('Đúng: $correct', textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -13,6 +13,7 @@ class HomeScreen extends StatelessWidget {
       _HomeItem(Icons.add_circle, 'Thêm từ', '/add'),
       _HomeItem(Icons.style, 'Flashcards', '/flash'),
       _HomeItem(Icons.quiz, 'Trắc nghiệm', '/quiz'),
+      _HomeItem(Icons.rule, 'TN Ngữ pháp', '/grammar-quiz'),
       _HomeItem(Icons.menu_book, 'Ngữ pháp', '/grammar'),
       _HomeItem(Icons.auto_awesome, 'Thống kê & SRS', '/stats'),
     ];


### PR DESCRIPTION
## Summary
- add grammar quiz screen using grammar presets
- link grammar quiz from home and router

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897743f82c48332a57626182b01f792