### PR TITLE
fix: correct ReviewLog imports in tests

### DIFF
--- a/test/database_service_unit_test.dart
+++ b/test/database_service_unit_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'dart:io';
 import '../lib/models/vocab.dart';
+import '../lib/models/review_log.dart';
 
 /// Unit test version of DatabaseService for testing CRUD operations
 class DatabaseServiceTest {

--- a/test/models/review_log_model_test.dart
+++ b/test/models/review_log_model_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/models/vocab.dart';
+import '../../lib/models/review_log.dart';
 
 void main() {
   group('ReviewLog Model Tests', () {

--- a/test/test_database_helper.dart
+++ b/test/test_database_helper.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:flutter/foundation.dart';
 import '../lib/models/vocab.dart';
+import '../lib/models/review_log.dart';
 
 class TestDatabaseHelper {
   static Database? _database;


### PR DESCRIPTION
## Summary
- add missing `ReviewLog` imports in test database helper and service tests
- update ReviewLog model tests to import the correct model

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897767783cc833288077f2e3bc84fae