### PR TITLE
feat: allow selecting JLPT level for grammar

### DIFF
--- a/assets/presets/grammar_n4.json
+++ b/assets/presets/grammar_n4.json
@@ -1,0 +1,4 @@
+[
+  {"title":"べきだ","meaning":"nên","level":"N4","example":"もっと勉強すべきだ。"},
+  {"title":"ために","meaning":"để","level":"N4","example":"日本語を学ぶために日本へ行く。"}
+]

--- a/lib/ui/screens/grammar_list_screen.dart
+++ b/lib/ui/screens/grammar_list_screen.dart
@@ -14,6 +14,9 @@ class _GrammarListScreenState extends State<GrammarListScreen> {
   List<Grammar>? _grammars;
   bool _loading = true;
   String? _error;
+  String _level = 'n5';
+
+  static const _levels = ['n5', 'n4', 'n3', 'n2', 'n1'];
 
   @override
   void initState() {
@@ -22,19 +25,33 @@ class _GrammarListScreenState extends State<GrammarListScreen> {
   }
 
   Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
     try {
-      final raw = await rootBundle.loadString('assets/presets/grammar_n5.json');
+      final raw =
+          await rootBundle.loadString('assets/presets/grammar_$_level.json');
       final list = jsonDecode(raw) as List;
       _grammars =
           list.map((e) => Grammar.fromMap(e as Map<String, dynamic>)).toList();
     } catch (e) {
       _error = e.toString();
+      _grammars = null;
     }
     if (mounted) {
       setState(() {
         _loading = false;
       });
     }
+  }
+
+  void _changeLevel(String? level) {
+    if (level == null || level == _level) return;
+    setState(() {
+      _level = level;
+    });
+    _load();
   }
 
   @override
@@ -53,7 +70,22 @@ class _GrammarListScreenState extends State<GrammarListScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Ngữ pháp N5')),
+      appBar: AppBar(
+        title: Text('Ngữ pháp ${_level.toUpperCase()}'),
+        actions: [
+          DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              key: const Key('levelDropdown'),
+              value: _level,
+              onChanged: _changeLevel,
+              items: _levels
+                  .map((l) =>
+                      DropdownMenuItem(value: l, child: Text(l.toUpperCase())))
+                  .toList(),
+            ),
+          )
+        ],
+      ),
       body: ListView.builder(
         itemCount: _grammars?.length ?? 0,
         itemBuilder: (context, index) {

--- a/lib/ui/screens/grammar_quiz_screen.dart
+++ b/lib/ui/screens/grammar_quiz_screen.dart
@@ -19,6 +19,8 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
   int correct = 0;
   List<Grammar> options = [];
   Grammar? current;
+  String _level = 'n5';
+  static const _levels = ['n5', 'n4', 'n3', 'n2', 'n1'];
 
   @override
   void initState() {
@@ -29,7 +31,7 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
   Future<void> _load() async {
     try {
       final raw =
-          await rootBundle.loadString('assets/presets/grammar_n5.json');
+          await rootBundle.loadString('assets/presets/grammar_$_level.json');
       final list = jsonDecode(raw) as List;
       pool =
           list.map((e) => Grammar.fromMap(e as Map<String, dynamic>)).toList();
@@ -38,6 +40,7 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
     } catch (e) {
       // ignore: avoid_print
       print('Error loading grammar: $e');
+      setState(() {});
     }
   }
 
@@ -53,16 +56,59 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
       ..shuffle(rng);
   }
 
+  void _changeLevel(String? level) {
+    if (level == null || level == _level) return;
+    setState(() {
+      _level = level;
+      pool = [];
+      options = [];
+      current = null;
+      qIndex = 0;
+      correct = 0;
+    });
+    _load();
+  }
+
   @override
   Widget build(BuildContext context) {
     if (current == null || options.isEmpty) {
       return Scaffold(
-          appBar: AppBar(title: const Text('Trắc nghiệm Ngữ pháp')),
+          appBar: AppBar(
+            title: Text('Trắc nghiệm Ngữ pháp ${_level.toUpperCase()}'),
+            actions: [
+              DropdownButtonHideUnderline(
+                child: DropdownButton<String>(
+                  key: const Key('levelDropdownQuiz'),
+                  value: _level,
+                  onChanged: _changeLevel,
+                  items: _levels
+                      .map((l) => DropdownMenuItem(
+                          value: l, child: Text(l.toUpperCase())))
+                      .toList(),
+                ),
+              )
+            ],
+          ),
           body: const Center(child: Text('Chưa đủ dữ liệu.')));
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Trắc nghiệm Ngữ pháp')),
+      appBar: AppBar(
+        title: Text('Trắc nghiệm Ngữ pháp ${_level.toUpperCase()}'),
+        actions: [
+          DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              key: const Key('levelDropdownQuiz'),
+              value: _level,
+              onChanged: _changeLevel,
+              items: _levels
+                  .map((l) =>
+                      DropdownMenuItem(value: l, child: Text(l.toUpperCase())))
+                  .toList(),
+            ),
+          )
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -108,4 +154,3 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
     );
   }
 }
-

--- a/test/grammar_list_screen_test.dart
+++ b/test/grammar_list_screen_test.dart
@@ -14,4 +14,19 @@ void main() {
     expect(find.text('は'), findsOneWidget);
     expect(find.text('trợ từ chỉ chủ đề'), findsOneWidget);
   });
+
+  testWidgets('GrammarListScreen allows level selection', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: GrammarListScreen()));
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('levelDropdown')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('N4').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ngữ pháp N4'), findsOneWidget);
+    expect(find.text('べきだ'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add JLPT level dropdown to grammar list and quiz screens
- include sample N4 grammar data
- test selecting grammar level

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_689777b18c7483329af257fd1fda9c72