### PR TITLE
Add Kanji management screens

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,5 +1,6 @@
 import 'package:go_router/go_router.dart';
 import './models/vocab.dart';
+import './models/kanji.dart';
 import 'ui/screens/home_screen.dart';
 import 'ui/screens/vocab_list_screen.dart';
 import 'ui/screens/add_edit_vocab_screen.dart';
@@ -7,6 +8,8 @@ import 'ui/screens/flashcards_screen.dart';
 import 'ui/screens/quiz_screen.dart';
 import 'ui/screens/kanji_flashcards_screen.dart';
 import 'ui/screens/kanji_quiz_screen.dart';
+import 'ui/screens/kanji_list_screen.dart';
+import 'ui/screens/add_edit_kanji_screen.dart';
 import 'ui/screens/stats_screen.dart';
 import 'ui/screens/grammar_list_screen.dart';
 import 'ui/screens/grammar_quiz_screen.dart';
@@ -23,6 +26,14 @@ final router = GoRouter(routes: [
   ),
   GoRoute(path: '/flash', builder: (_, __) => const FlashcardsScreen()),
   GoRoute(path: '/quiz', builder: (_, __) => const QuizScreen()),
+  GoRoute(path: '/kanji-list', builder: (_, __) => const KanjiListScreen()),
+  GoRoute(
+    path: '/kanji-add',
+    builder: (context, state) {
+      final kanji = state.extra as Kanji?;
+      return AddEditKanjiScreen(kanji: kanji);
+    },
+  ),
   GoRoute(path: '/kanji-flash', builder: (_, __) => const KanjiFlashcardsScreen()),
   GoRoute(path: '/kanji-quiz', builder: (_, __) => const KanjiQuizScreen()),
   GoRoute(path: '/grammar-quiz', builder: (_, __) => const GrammarQuizScreen()),

--- a/lib/ui/screens/add_edit_kanji_screen.dart
+++ b/lib/ui/screens/add_edit_kanji_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../models/kanji.dart';
+import '../../providers/providers.dart';
+
+class AddEditKanjiScreen extends ConsumerStatefulWidget {
+  final Kanji? kanji;
+  const AddEditKanjiScreen({super.key, this.kanji});
+
+  @override
+  ConsumerState<AddEditKanjiScreen> createState() => _State();
+}
+
+class _State extends ConsumerState<AddEditKanjiScreen> {
+  final _formKey = GlobalKey<FormState>();
+  String _character = '';
+  String _onyomi = '';
+  String _kunyomi = '';
+  String _meaning = '';
+  String _hanviet = '';
+  String _level = 'N5';
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.kanji != null) {
+      _character = widget.kanji!.character;
+      _onyomi = widget.kanji!.onyomi;
+      _kunyomi = widget.kanji!.kunyomi;
+      _meaning = widget.kanji!.meaning;
+      _hanviet = widget.kanji!.hanviet;
+      _level = widget.kanji!.level;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final db = ref.watch(databaseServiceProvider);
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.kanji == null ? 'Thêm kanji' : 'Sửa kanji')),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextFormField(
+              initialValue: _character,
+              decoration: const InputDecoration(labelText: 'Kanji'),
+              onSaved: (v) => _character = v!.trim(),
+              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập kanji' : null,
+            ),
+            TextFormField(
+              initialValue: _onyomi,
+              decoration: const InputDecoration(labelText: 'Onyomi'),
+              onSaved: (v) => _onyomi = v!.trim(),
+              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập onyomi' : null,
+            ),
+            TextFormField(
+              initialValue: _kunyomi,
+              decoration: const InputDecoration(labelText: 'Kunyomi'),
+              onSaved: (v) => _kunyomi = v!.trim(),
+              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập kunyomi' : null,
+            ),
+            TextFormField(
+              initialValue: _meaning,
+              decoration: const InputDecoration(labelText: 'Nghĩa'),
+              onSaved: (v) => _meaning = v!.trim(),
+              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập nghĩa' : null,
+            ),
+            TextFormField(
+              initialValue: _hanviet,
+              decoration: const InputDecoration(labelText: 'Hán Việt'),
+              onSaved: (v) => _hanviet = v!.trim(),
+              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập Hán Việt' : null,
+            ),
+            DropdownButtonFormField(
+              decoration: const InputDecoration(labelText: 'Cấp độ'),
+              value: _level,
+              items: const ['N5','N4','N3','N2','N1']
+                  .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                  .toList(),
+              onChanged: (v) => setState(() => _level = v as String),
+            ),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              icon: const Icon(Icons.save),
+              label: const Text('Lưu'),
+              onPressed: () async {
+                if (_formKey.currentState!.validate()) {
+                  _formKey.currentState!.save();
+                  try {
+                    if (!db.isInitialized) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Cơ sở dữ liệu chưa được khởi tạo. Vui lòng thử lại.'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                      return;
+                    }
+                    if (widget.kanji == null) {
+                      await db.addKanji(
+                        character: _character,
+                        onyomi: _onyomi,
+                        kunyomi: _kunyomi,
+                        meaning: _meaning,
+                        hanviet: _hanviet,
+                        level: _level,
+                      );
+                    } else {
+                      await db.updateKanji(
+                        widget.kanji!,
+                        character: _character,
+                        onyomi: _onyomi,
+                        kunyomi: _kunyomi,
+                        meaning: _meaning,
+                        hanviet: _hanviet,
+                        level: _level,
+                      );
+                    }
+                    if (mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(widget.kanji == null ? 'Đã thêm kanji' : 'Đã cập nhật kanji'),
+                          backgroundColor: Colors.green,
+                        ),
+                      );
+                      Navigator.pop(context);
+                    }
+                  } catch (e) {
+                    if (mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Lỗi: ${e.toString()}'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                    }
+                  }
+                }
+              },
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -11,6 +11,8 @@ class HomeScreen extends StatelessWidget {
     final items = [
       _HomeItem(Icons.list_alt, 'Danh sách', '/list'),
       _HomeItem(Icons.add_circle, 'Thêm từ', '/add'),
+      _HomeItem(Icons.view_list, 'DS Kanji', '/kanji-list'),
+      _HomeItem(Icons.add_box, 'Thêm Kanji', '/kanji-add'),
       _HomeItem(Icons.style, 'Flashcards', '/flash'),
       _HomeItem(Icons.quiz, 'Trắc nghiệm', '/quiz'),
       _HomeItem(Icons.style_outlined, 'Kanji Flash', '/kanji-flash'),

--- a/lib/ui/screens/kanji_list_screen.dart
+++ b/lib/ui/screens/kanji_list_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../models/kanji.dart';
+import '../../providers/providers.dart';
+import '../widgets/level_chip.dart';
+import '../widgets/kanji_tile.dart';
+
+class KanjiListScreen extends ConsumerWidget {
+  const KanjiListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final db = ref.watch(databaseServiceProvider);
+    final level = ref.watch(selectedLevelProvider);
+    const levels = ['N5', 'N4', 'N3', 'N2', 'N1'];
+
+    if (!db.isInitialized) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Kanji')),
+      body: Column(
+        children: [
+          SizedBox(
+            height: 52,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              children: [
+                const SizedBox(width: 8),
+                LevelChip(
+                    level: 'ALL',
+                    selected: level == null,
+                    onTap: () =>
+                        ref.read(selectedLevelProvider.notifier).state = null),
+                for (final lv in levels)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8.0),
+                    child: LevelChip(
+                      level: lv,
+                      selected: level == lv,
+                      onTap: () =>
+                          ref.read(selectedLevelProvider.notifier).state = lv,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: FutureBuilder<List<Kanji>>(
+              future: db.getAllKanjis(level: level),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (snapshot.hasError) {
+                  return Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.error, size: 64, color: Colors.red),
+                        const SizedBox(height: 16),
+                        Text('Lỗi: ${snapshot.error}'),
+                      ],
+                    ),
+                  );
+                }
+                final kanjis = snapshot.data ?? [];
+                if (kanjis.isEmpty) {
+                  return const Center(
+                    child: Text('Chưa có kanji nào. Hãy thêm mới!'),
+                  );
+                }
+                return ListView.builder(
+                  itemCount: kanjis.length,
+                  itemBuilder: (_, i) => KanjiTile(
+                    kanjis[i],
+                    onTap: () => context.go('/kanji-add', extra: kanjis[i]),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.go('/kanji-add'),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/kanji_tile.dart
+++ b/lib/ui/widgets/kanji_tile.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import '../../models/kanji.dart';
+
+class KanjiTile extends StatelessWidget {
+  final Kanji k;
+  final VoidCallback? onTap;
+  const KanjiTile(this.k, {super.key, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(k.character, style: Theme.of(context).textTheme.titleLarge),
+      subtitle: Text('${k.onyomi} / ${k.kunyomi} - ${k.meaning}'),
+      trailing: Text(k.level),
+      onTap: onTap,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add screen to list and filter kanji entries
- implement kanji add/edit form
- wire up routes and home shortcuts for new kanji screens

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689781518ccc833283c9d387fdbe8756