### PR TITLE
Fix test imports and mock database service

### DIFF
--- a/test/services/srs_service_test.dart
+++ b/test/services/srs_service_test.dart
@@ -1,13 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import '../test_database_helper.dart';
-import '../../lib/services/srs_service.dart';
-import '../../lib/services/database_service.dart';
-import '../../lib/models/vocab.dart';
+import 'package:nihongo_flashcard/services/srs_service.dart';
+import 'package:nihongo_flashcard/services/database_service.dart';
+import 'package:nihongo_flashcard/models/vocab.dart';
 
 /// Mock DatabaseService that implements the interface needed by SrsService
 class MockDatabaseService extends DatabaseService {
-  MockDatabaseService() : super();
-
   @override
   Future<void> updateVocabSrsData(Vocab vocab) async {
     return TestDatabaseService.updateVocabSrsData(vocab);

--- a/test/test_database_helper.dart
+++ b/test/test_database_helper.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:flutter/foundation.dart';
-import '../lib/models/vocab.dart';
-import '../lib/models/review_log.dart';
+import 'package:nihongo_flashcard/models/vocab.dart';
+import 'package:nihongo_flashcard/models/review_log.dart';
 
 class TestDatabaseHelper {
   static Database? _database;


### PR DESCRIPTION
## Summary
- use package imports for test helpers
- simplify MockDatabaseService to avoid missing constructor issue

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689784ba1ccc83329b12d4eee178b4db