### PR TITLE
feat(ci): run flutter tests via script

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -9,28 +9,25 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Setup Flutter SDK
       uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.32.8'
         channel: 'stable'
         cache: true
-    
-    - name: Install dependencies
-      run: flutter pub get
-    
-    - name: Verify Flutter installation
-      run: flutter doctor -v
-    
-    - name: Analyze code
-      run: flutter analyze
-    
-    - name: Run tests
-      run: flutter test --coverage
+
+    - name: Setup Java (for Android builds)
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Run tests and builds
+      run: ./test_app.sh
     
     - name: Upload coverage to Codecov
       if: success()
@@ -44,10 +41,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    
+
     strategy:
       matrix:
-        platform: [android, web]
+        platform: [web]
         
     steps:
     - uses: actions/checkout@v3
@@ -59,20 +56,8 @@ jobs:
         channel: 'stable'
         cache: true
     
-    - name: Setup Java (for Android builds)
-      if: matrix.platform == 'android'
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-    
     - name: Install dependencies
       run: flutter pub get
-    
-    - name: Build for Android
-      if: matrix.platform == 'android'
-      run: flutter build apk --debug
-      
+
     - name: Build for Web
-      if: matrix.platform == 'web'
       run: flutter build web --web-renderer html

--- a/test_app.sh
+++ b/test_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "🚀 Testing Nihongo App on both iOS and Android"
 
 # Kiểm tra Flutter doctor
@@ -23,24 +25,20 @@ echo "🔍 Running static analysis..."
 flutter analyze
 
 echo ""
-echo "🏗️  Testing iOS build..."
-flutter build ios --no-codesign
-if [ $? -eq 0 ]; then
-    echo "✅ iOS build successful!"
-else
-    echo "❌ iOS build failed!"
-    exit 1
+echo "🧪 Running tests with coverage..."
+flutter test --coverage
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo ""
+  echo "🏗️  Testing iOS build..."
+  flutter build ios --no-codesign
+  echo "✅ iOS build successful!"
 fi
 
 echo ""
 echo "🏗️  Testing Android build..."
 flutter build apk
-if [ $? -eq 0 ]; then
-    echo "✅ Android build successful!"
-else
-    echo "❌ Android build failed!"
-    exit 1
-fi
+echo "✅ Android build successful!"
 
 echo ""
 echo "🎉 All builds completed successfully!"


### PR DESCRIPTION
## Summary
- add test_app.sh to run flutter analysis, tests with coverage, and builds
- drive CI tests through test_app.sh and simplify build job

## Testing
- `./test_app.sh` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68979440993c8332b9b91730c5f8743b