### PR TITLE
feat: add grammar detail view

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,6 +1,7 @@
 import 'package:go_router/go_router.dart';
 import './models/vocab.dart';
 import './models/kanji.dart';
+import './models/grammar.dart';
 import 'ui/screens/main_screen.dart';
 import 'ui/screens/add_edit_vocab_screen.dart';
 import 'ui/screens/flashcards_screen.dart';
@@ -9,6 +10,7 @@ import 'ui/screens/kanji_flashcards_screen.dart';
 import 'ui/screens/kanji_quiz_screen.dart';
 import 'ui/screens/add_edit_kanji_screen.dart';
 import 'ui/screens/grammar_quiz_screen.dart';
+import 'ui/screens/grammar_detail_screen.dart';
 import 'ui/screens/stats_screen.dart';
 
 final router = GoRouter(routes: [
@@ -32,5 +34,12 @@ final router = GoRouter(routes: [
   GoRoute(path: '/kanji-flash', builder: (_, __) => const KanjiFlashcardsScreen()),
   GoRoute(path: '/kanji-quiz', builder: (_, __) => const KanjiQuizScreen()),
   GoRoute(path: '/grammar-quiz', builder: (_, __) => const GrammarQuizScreen()),
+  GoRoute(
+    path: '/grammar-detail',
+    builder: (context, state) {
+      final grammar = state.extra as Grammar;
+      return GrammarDetailScreen(grammar: grammar);
+    },
+  ),
   GoRoute(path: '/stats', builder: (_, __) => StatsScreen()),
 ]);

--- a/lib/ui/screens/grammar_detail_screen.dart
+++ b/lib/ui/screens/grammar_detail_screen.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../models/grammar.dart';
+
+class GrammarDetailScreen extends StatefulWidget {
+  final Grammar grammar;
+  const GrammarDetailScreen({super.key, required this.grammar});
+
+  @override
+  State<GrammarDetailScreen> createState() => _GrammarDetailScreenState();
+}
+
+class _GrammarDetailScreenState extends State<GrammarDetailScreen> {
+  late SharedPreferences _prefs;
+  bool _bookmarked = false;
+  late TextEditingController _noteController;
+  String _search = '';
+  double _fontSize = 16;
+
+  @override
+  void initState() {
+    super.initState();
+    _noteController = TextEditingController();
+    _init();
+  }
+
+  Future<void> _init() async {
+    _prefs = await SharedPreferences.getInstance();
+    final key = widget.grammar.title;
+    _bookmarked = _prefs.getBool('grammar_bookmark_$key') ?? false;
+    _noteController.text = _prefs.getString('grammar_note_$key') ?? '';
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _toggleBookmark() async {
+    setState(() => _bookmarked = !_bookmarked);
+    await _prefs.setBool(
+        'grammar_bookmark_${widget.grammar.title}', _bookmarked);
+  }
+
+  Future<void> _saveNote() async {
+    await _prefs.setString(
+        'grammar_note_${widget.grammar.title}', _noteController.text);
+  }
+
+  Future<void> _searchContent() async {
+    final q = await showSearch<String>(
+        context: context, delegate: _GrammarSearchDelegate());
+    if (q != null) {
+      setState(() {
+        _search = q;
+      });
+    }
+  }
+
+  TextSpan _buildHighlighted(String text) {
+    if (_search.isEmpty) {
+      return TextSpan(text: text, style: TextStyle(fontSize: _fontSize));
+    }
+    final lcText = text.toLowerCase();
+    final lcQuery = _search.toLowerCase();
+    final spans = <TextSpan>[];
+    int start = 0;
+    while (true) {
+      final index = lcText.indexOf(lcQuery, start);
+      if (index < 0) {
+        spans.add(TextSpan(
+            text: text.substring(start),
+            style: TextStyle(fontSize: _fontSize)));
+        break;
+      }
+      if (index > start) {
+        spans.add(TextSpan(
+            text: text.substring(start, index),
+            style: TextStyle(fontSize: _fontSize)));
+      }
+      spans.add(TextSpan(
+          text: text.substring(index, index + _search.length),
+          style: TextStyle(
+              fontSize: _fontSize, backgroundColor: Colors.yellow)));
+      start = index + _search.length;
+    }
+    return TextSpan(children: spans);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final g = widget.grammar;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(g.title),
+        actions: [
+          IconButton(
+              onPressed: _searchContent, icon: const Icon(Icons.search)),
+          IconButton(
+            icon: Icon(
+                _bookmarked ? Icons.bookmark : Icons.bookmark_border_outlined),
+            onPressed: _toggleBookmark,
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            RichText(text: _buildHighlighted(g.meaning)),
+            if (g.example != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: RichText(text: _buildHighlighted('Ví dụ: ${g.example}')),
+              ),
+            Padding(
+              padding: const EdgeInsets.only(top: 20),
+              child: TextField(
+                key: const Key('noteField'),
+                controller: _noteController,
+                maxLines: null,
+                decoration: const InputDecoration(
+                    labelText: 'Ghi chú', border: OutlineInputBorder()),
+                onChanged: (_) => _saveNote(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FloatingActionButton(
+            heroTag: 'zoomIn',
+            mini: true,
+            onPressed: () => setState(() => _fontSize += 2),
+            child: const Icon(Icons.zoom_in),
+          ),
+          const SizedBox(height: 8),
+          FloatingActionButton(
+            heroTag: 'zoomOut',
+            mini: true,
+            onPressed: () =>
+                setState(() => _fontSize = _fontSize > 12 ? _fontSize - 2 : 12),
+            child: const Icon(Icons.zoom_out),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GrammarSearchDelegate extends SearchDelegate<String> {
+  @override
+  List<Widget>? buildActions(BuildContext context) {
+    return [
+      IconButton(onPressed: () => query = '', icon: const Icon(Icons.clear))
+    ];
+  }
+
+  @override
+  Widget? buildLeading(BuildContext context) {
+    return IconButton(
+        onPressed: () => close(context, query),
+        icon: const Icon(Icons.arrow_back));
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    close(context, query);
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/ui/screens/grammar_list_screen.dart
+++ b/lib/ui/screens/grammar_list_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../../models/grammar.dart';
+import 'package:go_router/go_router.dart';
 
 class GrammarListScreen extends StatefulWidget {
   const GrammarListScreen({super.key});
@@ -106,6 +107,7 @@ class _GrammarListScreenState extends State<GrammarListScreen> {
                   ),
               ],
             ),
+            onTap: () => context.push('/grammar-detail', extra: g),
           );
         },
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   path_provider: ^2.1.4
   intl: ^0.20.2
   google_fonts: ^6.2.1
+  shared_preferences: ^2.2.2
 
   # UI
   flutter_staggered_animations: ^1.1.1

--- a/test/grammar_detail_screen_test.dart
+++ b/test/grammar_detail_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../lib/ui/screens/grammar_detail_screen.dart';
+import '../lib/models/grammar.dart';
+
+void main() {
+  testWidgets('GrammarDetailScreen shows content and toggles bookmark',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final grammar = Grammar(
+        title: 'test', meaning: 'meaning example', level: 'n5', example: 'ex');
+
+    await tester.pumpWidget(
+        MaterialApp(home: GrammarDetailScreen(grammar: grammar)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('meaning example'), findsOneWidget);
+    expect(find.byIcon(Icons.bookmark_border_outlined), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.bookmark_border_outlined));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.bookmark), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add detailed grammar view with bookmark, note, search and text zoom
- wire grammar list to new detail screen and add routing
- add widget test for bookmark toggle and dependency on shared_preferences

## Testing
- `flutter pub get` *(fails: command not found: flutter)*
- `dart format lib/ui/screens/grammar_detail_screen.dart lib/ui/screens/grammar_list_screen.dart lib/router.dart test/grammar_detail_screen_test.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689835a1ff148332a163480c15e4e404