### PR TITLE
docs: add usage and deployment wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ứng dụng Flutter quản lý từ vựng, ngữ pháp tiếng Nhật với hệ thống SRS (Spaced Repetition System) và flashcards.
 
+Tài liệu hướng dẫn chi tiết có trong [Wiki](wiki/Home.md).
+
 ## ✨ Tính năng
 
 - 📚 Quản lý từ vựng theo cấp độ JLPT (N5-N1)

--- a/wiki/Deployment.md
+++ b/wiki/Deployment.md
@@ -1,0 +1,34 @@
+# Triển khai ứng dụng
+
+Trang này hướng dẫn cách build và phát hành **Nihongo Flashcard**.
+
+## Yêu cầu
+- Flutter SDK >= 3.4.0
+- Dart >= 3.4.0
+- iOS >= 12.0
+- Android >= API 21
+
+## Build bản release
+
+### iOS
+```bash
+flutter build ios --release
+```
+
+### Android
+```bash
+flutter build apk --release
+```
+
+## Kiểm tra trước khi phát hành
+1. Chạy `flutter analyze` để kiểm tra mã nguồn.
+2. Chạy `flutter test` để đảm bảo các bài test đều pass.
+3. Tạo release build và thử nghiệm trên thiết bị thực tế.
+
+## Triển khai lên Store
+- **App Store:** upload bằng Xcode hoặc `transporter` sau khi có file `.ipa`.
+- **Google Play:** tải file `.aab` hoặc `.apk` lên Google Play Console, hoàn tất các bước kiểm duyệt.
+
+## Tài liệu tham khảo
+- [Publishing to the App Store](https://docs.flutter.dev/deployment/ios)
+- [Publishing to Google Play](https://docs.flutter.dev/deployment/android)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,8 @@
+# Nihongo Flashcard Wiki
+
+Chào mừng đến với wiki của dự án **Nihongo Flashcard**. Đây là nơi tổng hợp tài liệu hướng dẫn sử dụng và triển khai ứng dụng.
+
+- [Hướng dẫn sử dụng](Usage.md)
+- [Triển khai ứng dụng](Deployment.md)
+
+Nếu gặp vấn đề, hãy tạo issue trên GitHub hoặc tham khảo phần "Khắc phục sự cố" trong README.

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -1,0 +1,40 @@
+# Hướng dẫn sử dụng
+
+Trang này hướng dẫn cách cài đặt và sử dụng **Nihongo Flashcard**.
+
+## Cài đặt
+
+1. **Clone repository**
+   ```bash
+   git clone <repository-url>
+   cd nihongo-flashcard
+   ```
+2. **Cài đặt dependencies**
+   ```bash
+   flutter pub get
+   ```
+
+## Chạy ứng dụng
+
+### iOS
+```bash
+flutter run -d ios
+```
+
+### Android
+```bash
+flutter run -d android
+```
+
+## Các tính năng chính
+
+- Quản lý từ vựng và ngữ pháp theo cấp độ JLPT
+- Hệ thống ôn tập theo khoảng cách (SRS)
+- Flashcards và trắc nghiệm
+- Thống kê học tập
+
+## Mẹo sử dụng
+
+- Thêm từ vựng mới bằng nút "+" trong danh sách từ vựng.
+- Đánh giá độ nhớ từ 0-5 để SRS lên lịch ôn tập phù hợp.
+- Xem thống kê để theo dõi tiến độ học.


### PR DESCRIPTION
## Summary
- add Home, Usage, and Deployment wiki pages for Nihongo Flashcard
- link README to the new wiki documentation

## Testing
- `./test_app.sh` *(fails: Flutter is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6898362f08e48332884f8726a9a9e4bc