### PR TITLE
feat: add markdown editor for grammar content

### DIFF
--- a/lib/ui/screens/add_edit_grammar_screen.dart
+++ b/lib/ui/screens/add_edit_grammar_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/grammar.dart';
+import 'package:markdown_text_input/markdown_text_input.dart';
 
 class AddEditGrammarScreen extends StatefulWidget {
   const AddEditGrammarScreen({super.key});
@@ -47,12 +48,33 @@ class _AddEditGrammarScreenState extends State<AddEditGrammarScreen> {
               decoration: const InputDecoration(labelText: 'Ví dụ'),
               onSaved: (v) => _example = (v?.trim().isEmpty ?? true) ? null : v!.trim(),
             ),
-            TextFormField(
-              decoration:
-                  const InputDecoration(labelText: 'Nội dung (Markdown)'),
-              maxLines: 10,
-              onSaved: (v) => _content = v!.trim(),
-              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập nội dung' : null,
+            FormField<String>(
+              validator: (_) =>
+                  _content.trim().isEmpty ? 'Nhập nội dung' : null,
+              builder: (state) => Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  MarkdownTextInput(
+                    (String value) {
+                      _content = value;
+                      state.didChange(value);
+                    },
+                    _content,
+                    label: 'Nội dung',
+                    maxLines: 10,
+                    actions: MarkdownType.values,
+                  ),
+                  if (state.hasError)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(
+                        state.errorText!,
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.error),
+                      ),
+                    ),
+                ],
+              ),
             ),
             const SizedBox(height: 20),
             FilledButton.icon(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   google_fonts: ^6.2.1
   shared_preferences: ^2.2.2
   flutter_markdown: ^0.7.3
+  markdown_text_input: ^2.0.0
 
   # UI
   flutter_staggered_animations: ^1.1.1


### PR DESCRIPTION
## Summary
- allow rich Markdown formatting when adding grammar content
- include markdown_text_input dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68983ab8c8548332845c1d6276bb977b