### PR TITLE
Replace deprecated markdown_text_input dependency

### DIFF
--- a/lib/ui/screens/add_edit_grammar_screen.dart
+++ b/lib/ui/screens/add_edit_grammar_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/grammar.dart';
-import 'package:markdown_text_input/markdown_text_input.dart';
+import 'package:markdown_editor_plus/markdown_editor_plus.dart';
 
 class AddEditGrammarScreen extends StatefulWidget {
   const AddEditGrammarScreen({super.key});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   google_fonts: ^6.2.1
   shared_preferences: ^2.2.2
   flutter_markdown: ^0.7.3
-  markdown_text_input: ^2.0.0
+  markdown_editor_plus: ^2.0.0
 
   # UI
   flutter_staggered_animations: ^1.1.1


### PR DESCRIPTION
## Summary
- switch to `markdown_editor_plus` since `markdown_text_input` is unavailable
- update grammar screen import accordingly

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68985d0edb688332848dc71867490da8