### PR TITLE
test: add grammar feature tests

### DIFF
--- a/test/add_edit_grammar_screen_test.dart
+++ b/test/add_edit_grammar_screen_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nihongo_flashcard/models/grammar.dart';
+import 'package:nihongo_flashcard/ui/screens/add_edit_grammar_screen.dart';
+
+void main() {
+  testWidgets('AddEditGrammarScreen returns new grammar on save', (tester) async {
+    Grammar? result;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () async {
+            result = await Navigator.push<Grammar>(
+              context,
+              MaterialPageRoute(builder: (_) => const AddEditGrammarScreen()),
+            );
+          },
+          child: const Text('open'),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextFormField, 'Tiêu đề'), 'ている');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Nghĩa'), 'đang làm');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Ví dụ'), '本を読んでいる');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Nội dung'), 'content');
+
+    await tester.tap(find.text('Lưu'));
+    await tester.pumpAndSettle();
+
+    expect(result, isNotNull);
+    expect(result!.title, 'ている');
+    expect(result!.meaning, 'đang làm');
+    expect(result!.example, '本を読んでいる');
+    expect(result!.content, 'content');
+  });
+}

--- a/test/database_service_unit_test.dart
+++ b/test/database_service_unit_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'dart:io';
-import '../lib/models/vocab.dart';
-import '../lib/models/review_log.dart';
+import 'package:nihongo_flashcard/models/review_log.dart';
+import 'package:nihongo_flashcard/models/vocab.dart';
 
 /// Unit test version of DatabaseService for testing CRUD operations
 class DatabaseServiceTest {

--- a/test/grammar_detail_screen_test.dart
+++ b/test/grammar_detail_screen_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/ui/screens/grammar_detail_screen.dart';
-import '../lib/models/grammar.dart';
+import 'package:nihongo_flashcard/models/grammar.dart';
+import 'package:nihongo_flashcard/ui/screens/grammar_detail_screen.dart';
 
 void main() {
   testWidgets('GrammarDetailScreen shows markdown content and zoom icons',

--- a/test/grammar_list_screen_test.dart
+++ b/test/grammar_list_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/ui/screens/grammar_list_screen.dart';
+import 'package:nihongo_flashcard/ui/screens/add_edit_grammar_screen.dart';
+import 'package:nihongo_flashcard/ui/screens/grammar_list_screen.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
   testWidgets('GrammarListScreen loads and displays items', (tester) async {
@@ -28,5 +30,32 @@ void main() {
 
     expect(find.text('Ngữ pháp N4'), findsOneWidget);
     expect(find.text('べきだ'), findsOneWidget);
+  });
+
+  testWidgets('can add new grammar via AddEditGrammarScreen', (tester) async {
+    final router = GoRouter(routes: [
+      GoRoute(path: '/', builder: (_, __) => const GrammarListScreen()),
+      GoRoute(path: '/grammar-add', builder: (_, __) => const AddEditGrammarScreen()),
+    ]);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Tiêu đề'), 'テスト');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Nghĩa'), 'test meaning');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Ví dụ'), '例');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Nội dung'), 'content');
+
+    await tester.tap(find.text('Lưu'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('テスト'), findsOneWidget);
   });
 }

--- a/test/models/grammar_model_test.dart
+++ b/test/models/grammar_model_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/models/grammar.dart';
+import 'package:nihongo_flashcard/models/grammar.dart';
 
 void main() {
   group('Grammar Model Tests', () {

--- a/test/models/kanji_model_test.dart
+++ b/test/models/kanji_model_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/models/kanji.dart';
+import 'package:nihongo_flashcard/models/kanji.dart';
 
 void main() {
   group('Kanji Model Tests', () {

--- a/test/models/review_log_model_test.dart
+++ b/test/models/review_log_model_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/models/review_log.dart';
+import 'package:nihongo_flashcard/models/review_log.dart';
 
 void main() {
   group('ReviewLog Model Tests', () {

--- a/test/models/vocab_model_test.dart
+++ b/test/models/vocab_model_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import '../../lib/models/vocab.dart';
+import 'package:nihongo_flashcard/models/vocab.dart';
 
 void main() {
   group('Vocab Model Tests', () {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 
-import '../lib/app.dart';
+import 'package:nihongo_flashcard/app.dart';
 import 'test_database_helper.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- convert tests to package imports to fix analyzer issues
- cover AddEditGrammarScreen save flow
- verify GrammarListScreen can add new grammar entries

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689942347fd0833285ae928f114ee498