### PR TITLE
fix: resolve flutter analyze warnings

### DIFF
--- a/lib/ui/screens/add_edit_kanji_screen.dart
+++ b/lib/ui/screens/add_edit_kanji_screen.dart
@@ -118,24 +118,24 @@ class _State extends State<AddEditKanjiScreen> {
                         level: _level,
                       );
                     }
-                    if (mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(widget.kanji == null ? 'Đã thêm kanji' : 'Đã cập nhật kanji'),
-                          backgroundColor: Colors.green,
-                        ),
-                      );
-                      Navigator.pop(context);
-                    }
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(widget.kanji == null
+                            ? 'Đã thêm kanji'
+                            : 'Đã cập nhật kanji'),
+                        backgroundColor: Colors.green,
+                      ),
+                    );
+                    Navigator.pop(context);
                   } catch (e) {
-                    if (mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Lỗi: ${e.toString()}'),
-                          backgroundColor: Colors.red,
-                        ),
-                      );
-                    }
+                    if (!context.mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Lỗi: ${e.toString()}'),
+                        backgroundColor: Colors.red,
+                      ),
+                    );
                   }
                 }
               },

--- a/lib/ui/screens/add_edit_vocab_screen.dart
+++ b/lib/ui/screens/add_edit_vocab_screen.dart
@@ -99,7 +99,7 @@ class _State extends State<AddEditVocabScreen> {
                             note: _note);
                       }
 
-                      if (mounted) {
+                        if (!context.mounted) return;
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
                             content: Text(widget.vocab == null
@@ -109,9 +109,8 @@ class _State extends State<AddEditVocabScreen> {
                           ),
                         );
                         Navigator.pop(context);
-                      }
-                    } catch (e) {
-                      if (mounted) {
+                      } catch (e) {
+                        if (!context.mounted) return;
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
                             content: Text('Lỗi: ${e.toString()}'),
@@ -120,7 +119,6 @@ class _State extends State<AddEditVocabScreen> {
                         );
                       }
                     }
-                  }
                 },
               )
             ],

--- a/test/database_integration_test.dart
+++ b/test/database_integration_test.dart
@@ -161,14 +161,14 @@ void main() {
     });
 
     group('Favorites Tests', () {
-      test('Favorite operations', () async {
-        // Create some vocabs
-        final vocab1 = await TestDatabaseService.addVocab(
-          term: '好き', meaning: 'thích', level: 'N5', favorite: true);
-        final vocab2 = await TestDatabaseService.addVocab(
-          term: '嫌い', meaning: 'ghét', level: 'N5', favorite: false);
-        final vocab3 = await TestDatabaseService.addVocab(
-          term: '愛', meaning: 'yêu', level: 'N3', favorite: true);
+        test('Favorite operations', () async {
+          // Create some vocabs
+          await TestDatabaseService.addVocab(
+            term: '好き', meaning: 'thích', level: 'N5', favorite: true);
+          final vocab2 = await TestDatabaseService.addVocab(
+            term: '嫌い', meaning: 'ghét', level: 'N5', favorite: false);
+          await TestDatabaseService.addVocab(
+            term: '愛', meaning: 'yêu', level: 'N3', favorite: true);
 
         // Test favorite retrieval
         final favorites = await TestDatabaseService.getFavoriteVocabs();
@@ -248,9 +248,6 @@ void main() {
 
         // Test search performance on larger dataset
         final searchResults = await TestDatabaseService.searchVocabs('c');
-        // Debug: Let's see what we get
-        final searchTerms = searchResults.map((v) => '${v.term}:${v.meaning}').join(', ');
-        print('Search results for "c": $searchTerms');
         // Search for 'c' will match: chó, chim, cá, cây (4 results)
         expect(searchResults.length, 4);
 

--- a/test/services/srs_service_test.dart
+++ b/test/services/srs_service_test.dart
@@ -483,10 +483,9 @@ void main() {
         expect(srsService.daysUntilDue(vocab), equals(0));
       });
 
-      test('should handle very old and future dates', () {
-        final now = DateTime.now();
-        final veryOldDate = DateTime(1900, 1, 1);
-        final veryFutureDate = DateTime(2100, 12, 31);
+        test('should handle very old and future dates', () {
+          final veryOldDate = DateTime(1900, 1, 1);
+          final veryFutureDate = DateTime(2100, 12, 31);
         
         final oldVocab = _createTestVocab(dueAt: veryOldDate);
         final futureVocab = _createTestVocab(dueAt: veryFutureDate);

--- a/test/test_database_helper.dart
+++ b/test/test_database_helper.dart
@@ -1,11 +1,9 @@
 import 'dart:io';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
-import 'package:flutter/foundation.dart';
 import 'package:nihongo_flashcard/models/vocab.dart';
 import 'package:nihongo_flashcard/models/review_log.dart';
 
 class TestDatabaseHelper {
-  static Database? _database;
 
   /// Initialize sqflite_common_ffi for testing
   static void initializeFfiDb() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 


### PR DESCRIPTION
## Summary
- ensure context is mounted before showing dialogs
- clean up unused code and debug prints in tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689945a2f8b0833283d2037e52708b7c