### PR TITLE
feat: add basic grammar correction service

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tài liệu hướng dẫn chi tiết có trong [Wiki](wiki/Home.md).
 
 - 📚 Quản lý từ vựng theo cấp độ JLPT (N5-N1)
 - 📖 Thư viện ngữ pháp JLPT với ví dụ
+- ✏️ Sửa ngữ pháp cơ bản cho câu nhập vào
 - 🔄 Hệ thống ôn tập theo khoảng cách (SRS)
 - 📱 Flashcards tương tác
 - 🎯 Quiz và kiểm tra (từ vựng & ngữ pháp)

--- a/lib/services/grammar_service.dart
+++ b/lib/services/grammar_service.dart
@@ -1,0 +1,16 @@
+class GrammarService {
+  String correctGrammar(String input) {
+    if (input.trim().isEmpty) {
+      return '';
+    }
+    final trimmed = input.trim();
+    var corrected =
+        trimmed[0].toUpperCase() + trimmed.substring(1);
+    if (!corrected.endsWith('.') &&
+        !corrected.endsWith('!') &&
+        !corrected.endsWith('?')) {
+      corrected += '.';
+    }
+    return corrected;
+  }
+}

--- a/test/services/grammar_service_test.dart
+++ b/test/services/grammar_service_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nihongo_flashcard/services/grammar_service.dart';
+
+void main() {
+  final service = GrammarService();
+
+  test('adds capitalization and period', () {
+    expect(service.correctGrammar('hello world'), 'Hello world.');
+  });
+
+  test('keeps existing punctuation', () {
+    expect(service.correctGrammar('Hi there!'), 'Hi there!');
+  });
+
+  test('returns empty for whitespace', () {
+    expect(service.correctGrammar('   '), '');
+  });
+}


### PR DESCRIPTION
## Summary
- introduce GrammarService to tidy simple sentences
- cover grammar correction logic with unit tests
- document grammar correction capability

## Testing
- `dart format lib/services/grammar_service.dart test/services/grammar_service_test.dart` *(fails: command not found)*
- `curl -L --silent --show-error https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_latest-stable.tar.xz -o /tmp/flutter.tar.xz` *(fails: CONNECT tunnel failed: 403)*
- `flutter test test/services/grammar_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b99df9e88332bb7828772bdc5dfa