### PR TITLE
Add JLPT vocabulary presets with Vietnamese meanings and auto-import on startup

### DIFF
--- a/assets/presets/n1.json
+++ b/assets/presets/n1.json
@@ -1,0 +1,22 @@
+[
+  {"term": "顕著", "meaning": "đáng chú ý", "level": "N1"},
+  {"term": "緻密", "meaning": "tỉ mỉ", "level": "N1"},
+  {"term": "錯覚", "meaning": "ảo giác", "level": "N1"},
+  {"term": "曖昧", "meaning": "mơ hồ", "level": "N1"},
+  {"term": "醸成", "meaning": "hình thành", "level": "N1"},
+  {"term": "諮問", "meaning": "tham vấn", "level": "N1"},
+  {"term": "剥奪", "meaning": "tước đoạt", "level": "N1"},
+  {"term": "緩和", "meaning": "giảm bớt", "level": "N1"},
+  {"term": "遵守", "meaning": "tuân thủ", "level": "N1"},
+  {"term": "頒布", "meaning": "phân phát", "level": "N1"},
+  {"term": "勃発", "meaning": "bùng phát", "level": "N1"},
+  {"term": "婉曲", "meaning": "nói giảm", "level": "N1"},
+  {"term": "収斂", "meaning": "hội tụ", "level": "N1"},
+  {"term": "明瞭", "meaning": "rõ ràng", "level": "N1"},
+  {"term": "煩わしい", "meaning": "phiền phức", "level": "N1"},
+  {"term": "愚痴", "meaning": "than phiền", "level": "N1"},
+  {"term": "厳粛", "meaning": "trang nghiêm", "level": "N1"},
+  {"term": "侮辱", "meaning": "xúc phạm", "level": "N1"},
+  {"term": "憤慨", "meaning": "phẫn nộ", "level": "N1"},
+  {"term": "遺憾", "meaning": "đáng tiếc", "level": "N1"}
+]

--- a/assets/presets/n2.json
+++ b/assets/presets/n2.json
@@ -1,0 +1,22 @@
+[
+  {"term": "克服", "meaning": "khắc phục", "level": "N2"},
+  {"term": "徹底", "meaning": "triệt để", "level": "N2"},
+  {"term": "緊張", "meaning": "căng thẳng", "level": "N2"},
+  {"term": "継続", "meaning": "tiếp tục", "level": "N2"},
+  {"term": "妥当", "meaning": "hợp lý", "level": "N2"},
+  {"term": "控える", "meaning": "kiềm chế", "level": "N2"},
+  {"term": "依頼", "meaning": "yêu cầu", "level": "N2"},
+  {"term": "措置", "meaning": "biện pháp", "level": "N2"},
+  {"term": "推進", "meaning": "thúc đẩy", "level": "N2"},
+  {"term": "証拠", "meaning": "chứng cứ", "level": "N2"},
+  {"term": "把握", "meaning": "nắm bắt", "level": "N2"},
+  {"term": "摩擦", "meaning": "ma sát", "level": "N2"},
+  {"term": "維持", "meaning": "duy trì", "level": "N2"},
+  {"term": "促進", "meaning": "khuyến khích", "level": "N2"},
+  {"term": "黙る", "meaning": "im lặng", "level": "N2"},
+  {"term": "逆転", "meaning": "đảo ngược", "level": "N2"},
+  {"term": "至る", "meaning": "đạt tới", "level": "N2"},
+  {"term": "保障", "meaning": "bảo đảm", "level": "N2"},
+  {"term": "避難", "meaning": "sơ tán", "level": "N2"},
+  {"term": "展開", "meaning": "triển khai", "level": "N2"}
+]

--- a/assets/presets/n3.json
+++ b/assets/presets/n3.json
@@ -1,0 +1,22 @@
+[
+  {"term": "影響", "meaning": "ảnh hưởng", "level": "N3"},
+  {"term": "環境", "meaning": "môi trường", "level": "N3"},
+  {"term": "提供", "meaning": "cung cấp", "level": "N3"},
+  {"term": "可能性", "meaning": "khả năng", "level": "N3"},
+  {"term": "平均", "meaning": "trung bình", "level": "N3"},
+  {"term": "魅力", "meaning": "sức hấp dẫn", "level": "N3"},
+  {"term": "改善", "meaning": "cải thiện", "level": "N3"},
+  {"term": "判断", "meaning": "phán đoán", "level": "N3"},
+  {"term": "責任", "meaning": "trách nhiệm", "level": "N3"},
+  {"term": "費用", "meaning": "chi phí", "level": "N3"},
+  {"term": "状態", "meaning": "trạng thái", "level": "N3"},
+  {"term": "挑戦", "meaning": "thử thách", "level": "N3"},
+  {"term": "独立", "meaning": "độc lập", "level": "N3"},
+  {"term": "支援", "meaning": "hỗ trợ", "level": "N3"},
+  {"term": "状況", "meaning": "tình hình", "level": "N3"},
+  {"term": "拡大", "meaning": "mở rộng", "level": "N3"},
+  {"term": "詳細", "meaning": "chi tiết", "level": "N3"},
+  {"term": "必要性", "meaning": "sự cần thiết", "level": "N3"},
+  {"term": "対象", "meaning": "đối tượng", "level": "N3"},
+  {"term": "信頼", "meaning": "tin tưởng", "level": "N3"}
+]

--- a/assets/presets/n4.json
+++ b/assets/presets/n4.json
@@ -1,0 +1,22 @@
+[
+  {"term": "必要", "meaning": "cần thiết", "level": "N4"},
+  {"term": "自由", "meaning": "tự do", "level": "N4"},
+  {"term": "世界", "meaning": "thế giới", "level": "N4"},
+  {"term": "経験", "meaning": "kinh nghiệm", "level": "N4"},
+  {"term": "約束", "meaning": "lời hứa", "level": "N4"},
+  {"term": "調べる", "meaning": "điều tra", "level": "N4"},
+  {"term": "準備", "meaning": "chuẩn bị", "level": "N4"},
+  {"term": "発音", "meaning": "phát âm", "level": "N4"},
+  {"term": "場合", "meaning": "trường hợp", "level": "N4"},
+  {"term": "打つ", "meaning": "đánh", "level": "N4"},
+  {"term": "港", "meaning": "cảng", "level": "N4"},
+  {"term": "田舎", "meaning": "nông thôn", "level": "N4"},
+  {"term": "観光", "meaning": "tham quan", "level": "N4"},
+  {"term": "優しい", "meaning": "tốt bụng", "level": "N4"},
+  {"term": "込む", "meaning": "đông đúc", "level": "N4"},
+  {"term": "知らせる", "meaning": "thông báo", "level": "N4"},
+  {"term": "習慣", "meaning": "thói quen", "level": "N4"},
+  {"term": "記念", "meaning": "kỷ niệm", "level": "N4"},
+  {"term": "比べる", "meaning": "so sánh", "level": "N4"},
+  {"term": "相談", "meaning": "thảo luận", "level": "N4"}
+]

--- a/assets/presets/n5.json
+++ b/assets/presets/n5.json
@@ -1,5 +1,22 @@
 [
-  {"term":"猫","meaning":"con mèo","level":"N5","note":"neko"},
-  {"term":"犬","meaning":"con chó","level":"N5","note":"inu"},
-  {"term":"水","meaning":"nước","level":"N5"}
+  {"term": "学校", "meaning": "trường học", "level": "N5"},
+  {"term": "先生", "meaning": "giáo viên", "level": "N5"},
+  {"term": "学生", "meaning": "học sinh", "level": "N5"},
+  {"term": "猫", "meaning": "mèo", "level": "N5"},
+  {"term": "犬", "meaning": "chó", "level": "N5"},
+  {"term": "水", "meaning": "nước", "level": "N5"},
+  {"term": "火", "meaning": "lửa", "level": "N5"},
+  {"term": "木", "meaning": "cây", "level": "N5"},
+  {"term": "金", "meaning": "vàng", "level": "N5"},
+  {"term": "土", "meaning": "đất", "level": "N5"},
+  {"term": "日", "meaning": "ngày", "level": "N5"},
+  {"term": "月", "meaning": "tháng", "level": "N5"},
+  {"term": "車", "meaning": "xe hơi", "level": "N5"},
+  {"term": "電車", "meaning": "tàu điện", "level": "N5"},
+  {"term": "本", "meaning": "sách", "level": "N5"},
+  {"term": "食べる", "meaning": "ăn", "level": "N5"},
+  {"term": "飲む", "meaning": "uống", "level": "N5"},
+  {"term": "行く", "meaning": "đi", "level": "N5"},
+  {"term": "来る", "meaning": "đến", "level": "N5"},
+  {"term": "見る", "meaning": "nhìn", "level": "N5"}
 ]

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'services/migration_service.dart';
 import 'locator.dart';
 import 'services/database_service.dart';
+import 'services/preset_loader.dart';
 import 'app.dart';
 
 void main() async {
@@ -30,10 +31,21 @@ void main() async {
         // Continue anyway, as the app might still work
       }
     }
-    
+
     // Initialize the database service
     await databaseService.initialize();
-    
+
+    // Import preset vocabularies on first launch
+    final existing = await databaseService.getAllVocabs();
+    if (existing.isEmpty) {
+      final loader = PresetLoader(databaseService);
+      await loader.importJsonAsset('assets/presets/n5.json');
+      await loader.importJsonAsset('assets/presets/n4.json');
+      await loader.importJsonAsset('assets/presets/n3.json');
+      await loader.importJsonAsset('assets/presets/n2.json');
+      await loader.importJsonAsset('assets/presets/n1.json');
+    }
+
       runApp(
         const NihongoApp(),
       );


### PR DESCRIPTION
## Summary
- replace placeholder JLPT vocabulary with Vietnamese meanings for levels N5–N1
- load preset vocabulary files on first app launch

## Testing
- `./test_app.sh` *(fails: Flutter is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6899b9d421fc8332ae690596121a00a0