### PR TITLE
feat: enable editing of grammar items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tài liệu hướng dẫn chi tiết có trong [Wiki](wiki/Home.md).
 
 - 📚 Quản lý từ vựng theo cấp độ JLPT (N5-N1)
 - 📖 Thư viện ngữ pháp JLPT với ví dụ
+- ✏️ Chỉnh sửa mẫu ngữ pháp ngay trong danh sách
 - 🔄 Hệ thống ôn tập theo khoảng cách (SRS)
 - 📱 Flashcards tương tác
 - 🎯 Quiz và kiểm tra (từ vựng & ngữ pháp)

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -41,7 +41,13 @@ final router = GoRouter(routes: [
   GoRoute(path: '/kanji-flash', builder: (_, __) => const KanjiFlashcardsScreen()),
   GoRoute(path: '/kanji-quiz', builder: (_, __) => const KanjiQuizScreen()),
   GoRoute(path: '/grammar-quiz', builder: (_, __) => const GrammarQuizScreen()),
-  GoRoute(path: '/grammar-add', builder: (_, __) => const AddEditGrammarScreen()),
+  GoRoute(
+    path: '/grammar-add',
+    builder: (context, state) {
+      final grammar = state.extra as Grammar?;
+      return AddEditGrammarScreen(grammar: grammar);
+    },
+  ),
   GoRoute(
     path: '/grammar-detail',
     builder: (context, state) {

--- a/lib/ui/screens/add_edit_grammar_screen.dart
+++ b/lib/ui/screens/add_edit_grammar_screen.dart
@@ -3,7 +3,8 @@ import '../../models/grammar.dart';
 import '../widgets/simple_markdown_editor.dart';
 
 class AddEditGrammarScreen extends StatefulWidget {
-  const AddEditGrammarScreen({super.key});
+  final Grammar? grammar;
+  const AddEditGrammarScreen({super.key, this.grammar});
 
   @override
   State<AddEditGrammarScreen> createState() => _AddEditGrammarScreenState();
@@ -18,21 +19,37 @@ class _AddEditGrammarScreenState extends State<AddEditGrammarScreen> {
   String _content = '';
 
   @override
+  void initState() {
+    super.initState();
+    final g = widget.grammar;
+    if (g != null) {
+      _title = g.title;
+      _meaning = g.meaning;
+      _level = g.level;
+      _example = g.example;
+      _content = g.content;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Thêm ngữ pháp')),
+      appBar:
+          AppBar(title: Text(widget.grammar == null ? 'Thêm ngữ pháp' : 'Sửa ngữ pháp')),
       body: Form(
         key: _formKey,
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
             TextFormField(
+              initialValue: _title,
               decoration: const InputDecoration(labelText: 'Tiêu đề'),
               onSaved: (v) => _title = v!.trim(),
               validator: (v) =>
                   (v == null || v.trim().isEmpty) ? 'Nhập tiêu đề' : null,
             ),
             TextFormField(
+              initialValue: _meaning,
               decoration: const InputDecoration(labelText: 'Nghĩa'),
               onSaved: (v) => _meaning = v!.trim(),
               validator: (v) =>
@@ -47,6 +64,7 @@ class _AddEditGrammarScreenState extends State<AddEditGrammarScreen> {
               onChanged: (v) => setState(() => _level = v as String),
             ),
             TextFormField(
+              initialValue: _example,
               decoration: const InputDecoration(labelText: 'Ví dụ'),
               onSaved: (v) =>
                   _example = (v?.trim().isEmpty ?? true) ? null : v!.trim(),

--- a/lib/ui/screens/grammar_list_screen.dart
+++ b/lib/ui/screens/grammar_list_screen.dart
@@ -108,6 +108,30 @@ class _GrammarListScreenState extends State<GrammarListScreen> {
               ],
             ),
             onTap: () => context.push('/grammar-detail', extra: g),
+            onLongPress: () async {
+              final action = await showModalBottomSheet<String>(
+                context: context,
+                builder: (ctx) => SafeArea(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ListTile(
+                        leading: const Icon(Icons.edit),
+                        title: const Text('Sửa'),
+                        onTap: () => Navigator.pop(ctx, 'edit'),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+              if (action == 'edit') {
+                final updated =
+                    await context.push<Grammar>('/grammar-add', extra: g);
+                if (updated != null) {
+                  setState(() => _grammars![index] = updated);
+                }
+              }
+            },
           );
         },
       ),

--- a/test/add_edit_grammar_screen_test.dart
+++ b/test/add_edit_grammar_screen_test.dart
@@ -38,4 +38,21 @@ void main() {
     expect(result!.example, '本を読んでいる');
     expect(result!.content, 'content');
   });
+
+  testWidgets('AddEditGrammarScreen prefills data when editing', (tester) async {
+    final grammar = Grammar(
+      title: 'は',
+      meaning: 'chủ đề',
+      level: 'N5',
+      example: '猫はかわいい',
+      content: 'content',
+    );
+
+    await tester
+        .pumpWidget(MaterialApp(home: AddEditGrammarScreen(grammar: grammar)));
+
+    expect(find.text('は'), findsOneWidget);
+    expect(find.text('chủ đề'), findsOneWidget);
+    expect(find.text('猫はかわいい'), findsOneWidget);
+  });
 }

--- a/test/grammar_list_screen_test.dart
+++ b/test/grammar_list_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nihongo_flashcard/ui/screens/add_edit_grammar_screen.dart';
 import 'package:nihongo_flashcard/ui/screens/grammar_list_screen.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nihongo_flashcard/models/grammar.dart';
 
 void main() {
   testWidgets('GrammarListScreen loads and displays items', (tester) async {
@@ -35,7 +36,13 @@ void main() {
   testWidgets('can add new grammar via AddEditGrammarScreen', (tester) async {
     final router = GoRouter(routes: [
       GoRoute(path: '/', builder: (_, __) => const GrammarListScreen()),
-      GoRoute(path: '/grammar-add', builder: (_, __) => const AddEditGrammarScreen()),
+      GoRoute(
+        path: '/grammar-add',
+        builder: (context, state) {
+          final grammar = state.extra as Grammar?;
+          return AddEditGrammarScreen(grammar: grammar);
+        },
+      ),
     ]);
 
     await tester.pumpWidget(MaterialApp.router(routerConfig: router));
@@ -57,5 +64,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('テスト'), findsOneWidget);
+  });
+
+  testWidgets('can edit grammar via context menu', (tester) async {
+    final router = GoRouter(routes: [
+      GoRoute(path: '/', builder: (_, __) => const GrammarListScreen()),
+      GoRoute(
+        path: '/grammar-add',
+        builder: (context, state) {
+          final grammar = state.extra as Grammar?;
+          return AddEditGrammarScreen(grammar: grammar);
+        },
+      ),
+    ]);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.text('は').first);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Sửa'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Tiêu đề'), 'はね');
+    await tester.tap(find.text('Lưu'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('はね'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- allow long-pressing grammar list items to open an edit option and update entries
- prefill AddEditGrammarScreen with existing grammar data and document editing capability
- cover grammar editing flow with widget tests

## Testing
- `dart format lib/locator.dart lib/router.dart lib/ui/screens/add_edit_grammar_screen.dart lib/ui/screens/grammar_list_screen.dart lib/ui/screens/home_screen.dart test/add_edit_grammar_screen_test.dart test/grammar_list_screen_test.dart` *(fails: command not found: dart)*
- `curl -L --silent --show-error https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_latest-stable.tar.xz -o /tmp/flutter.tar.xz` *(fails: CONNECT tunnel failed, response 403)*
- `flutter test test/add_edit_grammar_screen_test.dart test/grammar_list_screen_test.dart` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_6899b99df9e88332bb7828772bdc5dfa