### PR TITLE
feat: add hiragana field for vocab

### DIFF
--- a/assets/presets/n1.json
+++ b/assets/presets/n1.json
@@ -1,22 +1,122 @@
 [
-  {"term": "顕著", "meaning": "đáng chú ý", "level": "N1"},
-  {"term": "緻密", "meaning": "tỉ mỉ", "level": "N1"},
-  {"term": "錯覚", "meaning": "ảo giác", "level": "N1"},
-  {"term": "曖昧", "meaning": "mơ hồ", "level": "N1"},
-  {"term": "醸成", "meaning": "hình thành", "level": "N1"},
-  {"term": "諮問", "meaning": "tham vấn", "level": "N1"},
-  {"term": "剥奪", "meaning": "tước đoạt", "level": "N1"},
-  {"term": "緩和", "meaning": "giảm bớt", "level": "N1"},
-  {"term": "遵守", "meaning": "tuân thủ", "level": "N1"},
-  {"term": "頒布", "meaning": "phân phát", "level": "N1"},
-  {"term": "勃発", "meaning": "bùng phát", "level": "N1"},
-  {"term": "婉曲", "meaning": "nói giảm", "level": "N1"},
-  {"term": "収斂", "meaning": "hội tụ", "level": "N1"},
-  {"term": "明瞭", "meaning": "rõ ràng", "level": "N1"},
-  {"term": "煩わしい", "meaning": "phiền phức", "level": "N1"},
-  {"term": "愚痴", "meaning": "than phiền", "level": "N1"},
-  {"term": "厳粛", "meaning": "trang nghiêm", "level": "N1"},
-  {"term": "侮辱", "meaning": "xúc phạm", "level": "N1"},
-  {"term": "憤慨", "meaning": "phẫn nộ", "level": "N1"},
-  {"term": "遺憾", "meaning": "đáng tiếc", "level": "N1"}
+  {
+    "term": "顕著",
+    "meaning": "đáng chú ý",
+    "level": "N1",
+    "hiragana": "けんちょ"
+  },
+  {
+    "term": "緻密",
+    "meaning": "tỉ mỉ",
+    "level": "N1",
+    "hiragana": "ちみつ"
+  },
+  {
+    "term": "錯覚",
+    "meaning": "ảo giác",
+    "level": "N1",
+    "hiragana": "さっかく"
+  },
+  {
+    "term": "曖昧",
+    "meaning": "mơ hồ",
+    "level": "N1",
+    "hiragana": "あいまい"
+  },
+  {
+    "term": "醸成",
+    "meaning": "hình thành",
+    "level": "N1",
+    "hiragana": "じょうせい"
+  },
+  {
+    "term": "諮問",
+    "meaning": "tham vấn",
+    "level": "N1",
+    "hiragana": "しもん"
+  },
+  {
+    "term": "剥奪",
+    "meaning": "tước đoạt",
+    "level": "N1",
+    "hiragana": "はくだつ"
+  },
+  {
+    "term": "緩和",
+    "meaning": "giảm bớt",
+    "level": "N1",
+    "hiragana": "かんわ"
+  },
+  {
+    "term": "遵守",
+    "meaning": "tuân thủ",
+    "level": "N1",
+    "hiragana": "じゅんしゅ"
+  },
+  {
+    "term": "頒布",
+    "meaning": "phân phát",
+    "level": "N1",
+    "hiragana": "はんぷ"
+  },
+  {
+    "term": "勃発",
+    "meaning": "bùng phát",
+    "level": "N1",
+    "hiragana": "ぼっぱつ"
+  },
+  {
+    "term": "婉曲",
+    "meaning": "nói giảm",
+    "level": "N1",
+    "hiragana": "えんきょく"
+  },
+  {
+    "term": "収斂",
+    "meaning": "hội tụ",
+    "level": "N1",
+    "hiragana": "しゅうれん"
+  },
+  {
+    "term": "明瞭",
+    "meaning": "rõ ràng",
+    "level": "N1",
+    "hiragana": "めいりょう"
+  },
+  {
+    "term": "煩わしい",
+    "meaning": "phiền phức",
+    "level": "N1",
+    "hiragana": "わずらわしい"
+  },
+  {
+    "term": "愚痴",
+    "meaning": "than phiền",
+    "level": "N1",
+    "hiragana": "ぐち"
+  },
+  {
+    "term": "厳粛",
+    "meaning": "trang nghiêm",
+    "level": "N1",
+    "hiragana": "げんしゅく"
+  },
+  {
+    "term": "侮辱",
+    "meaning": "xúc phạm",
+    "level": "N1",
+    "hiragana": "ぶじょく"
+  },
+  {
+    "term": "憤慨",
+    "meaning": "phẫn nộ",
+    "level": "N1",
+    "hiragana": "ふんがい"
+  },
+  {
+    "term": "遺憾",
+    "meaning": "đáng tiếc",
+    "level": "N1",
+    "hiragana": "いかん"
+  }
 ]

--- a/assets/presets/n2.json
+++ b/assets/presets/n2.json
@@ -1,22 +1,122 @@
 [
-  {"term": "克服", "meaning": "khắc phục", "level": "N2"},
-  {"term": "徹底", "meaning": "triệt để", "level": "N2"},
-  {"term": "緊張", "meaning": "căng thẳng", "level": "N2"},
-  {"term": "継続", "meaning": "tiếp tục", "level": "N2"},
-  {"term": "妥当", "meaning": "hợp lý", "level": "N2"},
-  {"term": "控える", "meaning": "kiềm chế", "level": "N2"},
-  {"term": "依頼", "meaning": "yêu cầu", "level": "N2"},
-  {"term": "措置", "meaning": "biện pháp", "level": "N2"},
-  {"term": "推進", "meaning": "thúc đẩy", "level": "N2"},
-  {"term": "証拠", "meaning": "chứng cứ", "level": "N2"},
-  {"term": "把握", "meaning": "nắm bắt", "level": "N2"},
-  {"term": "摩擦", "meaning": "ma sát", "level": "N2"},
-  {"term": "維持", "meaning": "duy trì", "level": "N2"},
-  {"term": "促進", "meaning": "khuyến khích", "level": "N2"},
-  {"term": "黙る", "meaning": "im lặng", "level": "N2"},
-  {"term": "逆転", "meaning": "đảo ngược", "level": "N2"},
-  {"term": "至る", "meaning": "đạt tới", "level": "N2"},
-  {"term": "保障", "meaning": "bảo đảm", "level": "N2"},
-  {"term": "避難", "meaning": "sơ tán", "level": "N2"},
-  {"term": "展開", "meaning": "triển khai", "level": "N2"}
+  {
+    "term": "克服",
+    "meaning": "khắc phục",
+    "level": "N2",
+    "hiragana": "こくふく"
+  },
+  {
+    "term": "徹底",
+    "meaning": "triệt để",
+    "level": "N2",
+    "hiragana": "てってい"
+  },
+  {
+    "term": "緊張",
+    "meaning": "căng thẳng",
+    "level": "N2",
+    "hiragana": "きんちょう"
+  },
+  {
+    "term": "継続",
+    "meaning": "tiếp tục",
+    "level": "N2",
+    "hiragana": "けいぞく"
+  },
+  {
+    "term": "妥当",
+    "meaning": "hợp lý",
+    "level": "N2",
+    "hiragana": "だとう"
+  },
+  {
+    "term": "控える",
+    "meaning": "kiềm chế",
+    "level": "N2",
+    "hiragana": "ひかえる"
+  },
+  {
+    "term": "依頼",
+    "meaning": "yêu cầu",
+    "level": "N2",
+    "hiragana": "いらい"
+  },
+  {
+    "term": "措置",
+    "meaning": "biện pháp",
+    "level": "N2",
+    "hiragana": "そち"
+  },
+  {
+    "term": "推進",
+    "meaning": "thúc đẩy",
+    "level": "N2",
+    "hiragana": "すいしん"
+  },
+  {
+    "term": "証拠",
+    "meaning": "chứng cứ",
+    "level": "N2",
+    "hiragana": "しょうこ"
+  },
+  {
+    "term": "把握",
+    "meaning": "nắm bắt",
+    "level": "N2",
+    "hiragana": "はあく"
+  },
+  {
+    "term": "摩擦",
+    "meaning": "ma sát",
+    "level": "N2",
+    "hiragana": "まさつ"
+  },
+  {
+    "term": "維持",
+    "meaning": "duy trì",
+    "level": "N2",
+    "hiragana": "いじ"
+  },
+  {
+    "term": "促進",
+    "meaning": "khuyến khích",
+    "level": "N2",
+    "hiragana": "そくしん"
+  },
+  {
+    "term": "黙る",
+    "meaning": "im lặng",
+    "level": "N2",
+    "hiragana": "だまる"
+  },
+  {
+    "term": "逆転",
+    "meaning": "đảo ngược",
+    "level": "N2",
+    "hiragana": "ぎゃくてん"
+  },
+  {
+    "term": "至る",
+    "meaning": "đạt tới",
+    "level": "N2",
+    "hiragana": "いたる"
+  },
+  {
+    "term": "保障",
+    "meaning": "bảo đảm",
+    "level": "N2",
+    "hiragana": "ほしょう"
+  },
+  {
+    "term": "避難",
+    "meaning": "sơ tán",
+    "level": "N2",
+    "hiragana": "ひなん"
+  },
+  {
+    "term": "展開",
+    "meaning": "triển khai",
+    "level": "N2",
+    "hiragana": "てんかい"
+  }
 ]

--- a/assets/presets/n3.json
+++ b/assets/presets/n3.json
@@ -1,22 +1,122 @@
 [
-  {"term": "影響", "meaning": "ảnh hưởng", "level": "N3"},
-  {"term": "環境", "meaning": "môi trường", "level": "N3"},
-  {"term": "提供", "meaning": "cung cấp", "level": "N3"},
-  {"term": "可能性", "meaning": "khả năng", "level": "N3"},
-  {"term": "平均", "meaning": "trung bình", "level": "N3"},
-  {"term": "魅力", "meaning": "sức hấp dẫn", "level": "N3"},
-  {"term": "改善", "meaning": "cải thiện", "level": "N3"},
-  {"term": "判断", "meaning": "phán đoán", "level": "N3"},
-  {"term": "責任", "meaning": "trách nhiệm", "level": "N3"},
-  {"term": "費用", "meaning": "chi phí", "level": "N3"},
-  {"term": "状態", "meaning": "trạng thái", "level": "N3"},
-  {"term": "挑戦", "meaning": "thử thách", "level": "N3"},
-  {"term": "独立", "meaning": "độc lập", "level": "N3"},
-  {"term": "支援", "meaning": "hỗ trợ", "level": "N3"},
-  {"term": "状況", "meaning": "tình hình", "level": "N3"},
-  {"term": "拡大", "meaning": "mở rộng", "level": "N3"},
-  {"term": "詳細", "meaning": "chi tiết", "level": "N3"},
-  {"term": "必要性", "meaning": "sự cần thiết", "level": "N3"},
-  {"term": "対象", "meaning": "đối tượng", "level": "N3"},
-  {"term": "信頼", "meaning": "tin tưởng", "level": "N3"}
+  {
+    "term": "影響",
+    "meaning": "ảnh hưởng",
+    "level": "N3",
+    "hiragana": "えいきょう"
+  },
+  {
+    "term": "環境",
+    "meaning": "môi trường",
+    "level": "N3",
+    "hiragana": "かんきょう"
+  },
+  {
+    "term": "提供",
+    "meaning": "cung cấp",
+    "level": "N3",
+    "hiragana": "ていきょう"
+  },
+  {
+    "term": "可能性",
+    "meaning": "khả năng",
+    "level": "N3",
+    "hiragana": "かのうせい"
+  },
+  {
+    "term": "平均",
+    "meaning": "trung bình",
+    "level": "N3",
+    "hiragana": "へいきん"
+  },
+  {
+    "term": "魅力",
+    "meaning": "sức hấp dẫn",
+    "level": "N3",
+    "hiragana": "みりょく"
+  },
+  {
+    "term": "改善",
+    "meaning": "cải thiện",
+    "level": "N3",
+    "hiragana": "かいぜん"
+  },
+  {
+    "term": "判断",
+    "meaning": "phán đoán",
+    "level": "N3",
+    "hiragana": "はんだん"
+  },
+  {
+    "term": "責任",
+    "meaning": "trách nhiệm",
+    "level": "N3",
+    "hiragana": "せきにん"
+  },
+  {
+    "term": "費用",
+    "meaning": "chi phí",
+    "level": "N3",
+    "hiragana": "ひよう"
+  },
+  {
+    "term": "状態",
+    "meaning": "trạng thái",
+    "level": "N3",
+    "hiragana": "じょうたい"
+  },
+  {
+    "term": "挑戦",
+    "meaning": "thử thách",
+    "level": "N3",
+    "hiragana": "ちょうせん"
+  },
+  {
+    "term": "独立",
+    "meaning": "độc lập",
+    "level": "N3",
+    "hiragana": "どくりつ"
+  },
+  {
+    "term": "支援",
+    "meaning": "hỗ trợ",
+    "level": "N3",
+    "hiragana": "しえん"
+  },
+  {
+    "term": "状況",
+    "meaning": "tình hình",
+    "level": "N3",
+    "hiragana": "じょうきょう"
+  },
+  {
+    "term": "拡大",
+    "meaning": "mở rộng",
+    "level": "N3",
+    "hiragana": "かくだい"
+  },
+  {
+    "term": "詳細",
+    "meaning": "chi tiết",
+    "level": "N3",
+    "hiragana": "しょうさい"
+  },
+  {
+    "term": "必要性",
+    "meaning": "sự cần thiết",
+    "level": "N3",
+    "hiragana": "ひつようせい"
+  },
+  {
+    "term": "対象",
+    "meaning": "đối tượng",
+    "level": "N3",
+    "hiragana": "たいしょう"
+  },
+  {
+    "term": "信頼",
+    "meaning": "tin tưởng",
+    "level": "N3",
+    "hiragana": "しんらい"
+  }
 ]

--- a/assets/presets/n4.json
+++ b/assets/presets/n4.json
@@ -1,22 +1,122 @@
 [
-  {"term": "必要", "meaning": "cần thiết", "level": "N4"},
-  {"term": "自由", "meaning": "tự do", "level": "N4"},
-  {"term": "世界", "meaning": "thế giới", "level": "N4"},
-  {"term": "経験", "meaning": "kinh nghiệm", "level": "N4"},
-  {"term": "約束", "meaning": "lời hứa", "level": "N4"},
-  {"term": "調べる", "meaning": "điều tra", "level": "N4"},
-  {"term": "準備", "meaning": "chuẩn bị", "level": "N4"},
-  {"term": "発音", "meaning": "phát âm", "level": "N4"},
-  {"term": "場合", "meaning": "trường hợp", "level": "N4"},
-  {"term": "打つ", "meaning": "đánh", "level": "N4"},
-  {"term": "港", "meaning": "cảng", "level": "N4"},
-  {"term": "田舎", "meaning": "nông thôn", "level": "N4"},
-  {"term": "観光", "meaning": "tham quan", "level": "N4"},
-  {"term": "優しい", "meaning": "tốt bụng", "level": "N4"},
-  {"term": "込む", "meaning": "đông đúc", "level": "N4"},
-  {"term": "知らせる", "meaning": "thông báo", "level": "N4"},
-  {"term": "習慣", "meaning": "thói quen", "level": "N4"},
-  {"term": "記念", "meaning": "kỷ niệm", "level": "N4"},
-  {"term": "比べる", "meaning": "so sánh", "level": "N4"},
-  {"term": "相談", "meaning": "thảo luận", "level": "N4"}
+  {
+    "term": "必要",
+    "meaning": "cần thiết",
+    "level": "N4",
+    "hiragana": "ひつよう"
+  },
+  {
+    "term": "自由",
+    "meaning": "tự do",
+    "level": "N4",
+    "hiragana": "じゆう"
+  },
+  {
+    "term": "世界",
+    "meaning": "thế giới",
+    "level": "N4",
+    "hiragana": "せかい"
+  },
+  {
+    "term": "経験",
+    "meaning": "kinh nghiệm",
+    "level": "N4",
+    "hiragana": "けいけん"
+  },
+  {
+    "term": "約束",
+    "meaning": "lời hứa",
+    "level": "N4",
+    "hiragana": "やくそく"
+  },
+  {
+    "term": "調べる",
+    "meaning": "điều tra",
+    "level": "N4",
+    "hiragana": "しらべる"
+  },
+  {
+    "term": "準備",
+    "meaning": "chuẩn bị",
+    "level": "N4",
+    "hiragana": "じゅんび"
+  },
+  {
+    "term": "発音",
+    "meaning": "phát âm",
+    "level": "N4",
+    "hiragana": "はつおん"
+  },
+  {
+    "term": "場合",
+    "meaning": "trường hợp",
+    "level": "N4",
+    "hiragana": "ばあい"
+  },
+  {
+    "term": "打つ",
+    "meaning": "đánh",
+    "level": "N4",
+    "hiragana": "うつ"
+  },
+  {
+    "term": "港",
+    "meaning": "cảng",
+    "level": "N4",
+    "hiragana": "みなと"
+  },
+  {
+    "term": "田舎",
+    "meaning": "nông thôn",
+    "level": "N4",
+    "hiragana": "いなか"
+  },
+  {
+    "term": "観光",
+    "meaning": "tham quan",
+    "level": "N4",
+    "hiragana": "かんこう"
+  },
+  {
+    "term": "優しい",
+    "meaning": "tốt bụng",
+    "level": "N4",
+    "hiragana": "やさしい"
+  },
+  {
+    "term": "込む",
+    "meaning": "đông đúc",
+    "level": "N4",
+    "hiragana": "こむ"
+  },
+  {
+    "term": "知らせる",
+    "meaning": "thông báo",
+    "level": "N4",
+    "hiragana": "しらせる"
+  },
+  {
+    "term": "習慣",
+    "meaning": "thói quen",
+    "level": "N4",
+    "hiragana": "しゅうかん"
+  },
+  {
+    "term": "記念",
+    "meaning": "kỷ niệm",
+    "level": "N4",
+    "hiragana": "きねん"
+  },
+  {
+    "term": "比べる",
+    "meaning": "so sánh",
+    "level": "N4",
+    "hiragana": "くらべる"
+  },
+  {
+    "term": "相談",
+    "meaning": "thảo luận",
+    "level": "N4",
+    "hiragana": "そうだん"
+  }
 ]

--- a/assets/presets/n5.json
+++ b/assets/presets/n5.json
@@ -1,22 +1,122 @@
 [
-  {"term": "学校", "meaning": "trường học", "level": "N5"},
-  {"term": "先生", "meaning": "giáo viên", "level": "N5"},
-  {"term": "学生", "meaning": "học sinh", "level": "N5"},
-  {"term": "猫", "meaning": "mèo", "level": "N5"},
-  {"term": "犬", "meaning": "chó", "level": "N5"},
-  {"term": "水", "meaning": "nước", "level": "N5"},
-  {"term": "火", "meaning": "lửa", "level": "N5"},
-  {"term": "木", "meaning": "cây", "level": "N5"},
-  {"term": "金", "meaning": "vàng", "level": "N5"},
-  {"term": "土", "meaning": "đất", "level": "N5"},
-  {"term": "日", "meaning": "ngày", "level": "N5"},
-  {"term": "月", "meaning": "tháng", "level": "N5"},
-  {"term": "車", "meaning": "xe hơi", "level": "N5"},
-  {"term": "電車", "meaning": "tàu điện", "level": "N5"},
-  {"term": "本", "meaning": "sách", "level": "N5"},
-  {"term": "食べる", "meaning": "ăn", "level": "N5"},
-  {"term": "飲む", "meaning": "uống", "level": "N5"},
-  {"term": "行く", "meaning": "đi", "level": "N5"},
-  {"term": "来る", "meaning": "đến", "level": "N5"},
-  {"term": "見る", "meaning": "nhìn", "level": "N5"}
+  {
+    "term": "学校",
+    "meaning": "trường học",
+    "level": "N5",
+    "hiragana": "がっこう"
+  },
+  {
+    "term": "先生",
+    "meaning": "giáo viên",
+    "level": "N5",
+    "hiragana": "せんせい"
+  },
+  {
+    "term": "学生",
+    "meaning": "học sinh",
+    "level": "N5",
+    "hiragana": "がくせい"
+  },
+  {
+    "term": "猫",
+    "meaning": "mèo",
+    "level": "N5",
+    "hiragana": "ねこ"
+  },
+  {
+    "term": "犬",
+    "meaning": "chó",
+    "level": "N5",
+    "hiragana": "いぬ"
+  },
+  {
+    "term": "水",
+    "meaning": "nước",
+    "level": "N5",
+    "hiragana": "みず"
+  },
+  {
+    "term": "火",
+    "meaning": "lửa",
+    "level": "N5",
+    "hiragana": "ひ"
+  },
+  {
+    "term": "木",
+    "meaning": "cây",
+    "level": "N5",
+    "hiragana": "き"
+  },
+  {
+    "term": "金",
+    "meaning": "vàng",
+    "level": "N5",
+    "hiragana": "きん"
+  },
+  {
+    "term": "土",
+    "meaning": "đất",
+    "level": "N5",
+    "hiragana": "つち"
+  },
+  {
+    "term": "日",
+    "meaning": "ngày",
+    "level": "N5",
+    "hiragana": "ひ"
+  },
+  {
+    "term": "月",
+    "meaning": "tháng",
+    "level": "N5",
+    "hiragana": "つき"
+  },
+  {
+    "term": "車",
+    "meaning": "xe hơi",
+    "level": "N5",
+    "hiragana": "くるま"
+  },
+  {
+    "term": "電車",
+    "meaning": "tàu điện",
+    "level": "N5",
+    "hiragana": "でんしゃ"
+  },
+  {
+    "term": "本",
+    "meaning": "sách",
+    "level": "N5",
+    "hiragana": "ほん"
+  },
+  {
+    "term": "食べる",
+    "meaning": "ăn",
+    "level": "N5",
+    "hiragana": "たべる"
+  },
+  {
+    "term": "飲む",
+    "meaning": "uống",
+    "level": "N5",
+    "hiragana": "のむ"
+  },
+  {
+    "term": "行く",
+    "meaning": "đi",
+    "level": "N5",
+    "hiragana": "いく"
+  },
+  {
+    "term": "来る",
+    "meaning": "đến",
+    "level": "N5",
+    "hiragana": "くる"
+  },
+  {
+    "term": "見る",
+    "meaning": "nhìn",
+    "level": "N5",
+    "hiragana": "みる"
+  }
 ]

--- a/lib/models/vocab.dart
+++ b/lib/models/vocab.dart
@@ -1,6 +1,7 @@
 class Vocab {
   int? id;
   String term;
+  String hiragana;
   String meaning;
   String level;
   String? note;
@@ -22,6 +23,7 @@ class Vocab {
   Vocab({
     this.id,
     required this.term,
+    required this.hiragana,
     required this.meaning,
     required this.level,
     this.note,
@@ -39,6 +41,7 @@ class Vocab {
     return {
       'id': id,
       'term': term,
+      'hiragana': hiragana,
       'meaning': meaning,
       'level': level,
       'note': note,
@@ -57,6 +60,7 @@ class Vocab {
     return Vocab(
       id: map['id'],
       term: map['term'],
+      hiragana: map['hiragana'],
       meaning: map['meaning'],
       level: map['level'],
       note: map['note'],
@@ -79,6 +83,7 @@ class Vocab {
   Vocab copyWith({
     int? id,
     String? term,
+    String? hiragana,
     String? meaning,
     String? level,
     String? note,
@@ -94,6 +99,7 @@ class Vocab {
     return Vocab(
       id: id ?? this.id,
       term: term ?? this.term,
+      hiragana: hiragana ?? this.hiragana,
       meaning: meaning ?? this.meaning,
       level: level ?? this.level,
       note: note ?? this.note,
@@ -114,6 +120,7 @@ class Vocab {
     return other is Vocab &&
         other.id == id &&
         other.term == term &&
+        other.hiragana == hiragana &&
         other.meaning == meaning &&
         other.level == level &&
         other.note == note &&
@@ -132,6 +139,7 @@ class Vocab {
     return Object.hash(
       id,
       term,
+      hiragana,
       meaning,
       level,
       note,
@@ -148,6 +156,6 @@ class Vocab {
 
   @override
   String toString() {
-    return 'Vocab{id: $id, term: $term, meaning: $meaning, level: $level, note: $note, easiness: $easiness, repetitions: $repetitions, intervalDays: $intervalDays, lastReviewedAt: $lastReviewedAt, dueAt: $dueAt, favorite: $favorite, createdAt: $createdAt, updatedAt: $updatedAt}';
+    return 'Vocab{' 'id: $id, term: $term, hiragana: $hiragana, meaning: $meaning, level: $level, note: $note, ' 'easiness: $easiness, repetitions: $repetitions, intervalDays: $intervalDays, lastReviewedAt: $lastReviewedAt, ' 'dueAt: $dueAt, favorite: $favorite, createdAt: $createdAt, updatedAt: $updatedAt}';
   }
 }

--- a/lib/services/migration_service.dart
+++ b/lib/services/migration_service.dart
@@ -37,8 +37,8 @@ class MigrationService {
           // Check if the structure matches our current schema
           final vocabColumns = await db.rawQuery('PRAGMA table_info(vocabs)');
           final expectedColumns = {
-            'id', 'term', 'meaning', 'level', 'note', 'easiness', 
-            'repetitions', 'intervalDays', 'lastReviewedAt', 'dueAt', 
+            'id', 'term', 'hiragana', 'meaning', 'level', 'note', 'easiness',
+            'repetitions', 'intervalDays', 'lastReviewedAt', 'dueAt',
             'favorite', 'createdAt', 'updatedAt'
           };
           
@@ -183,6 +183,7 @@ class MigrationService {
     try {
       // Ensure required fields exist and have proper types
       final term = oldData['term']?.toString() ?? '';
+      final hiragana = oldData['hiragana']?.toString() ?? term;
       final meaning = oldData['meaning']?.toString() ?? '';
       final level = oldData['level']?.toString() ?? 'N5';
       
@@ -206,6 +207,7 @@ class MigrationService {
       // Create new vocab record
       final vocab = Vocab(
         term: term,
+        hiragana: hiragana,
         meaning: meaning,
         level: level,
         note: note,
@@ -222,6 +224,7 @@ class MigrationService {
       // Insert using database service
       await dbService.addVocab(
         term: vocab.term,
+        hiragana: vocab.hiragana,
         meaning: vocab.meaning,
         level: vocab.level,
         note: vocab.note,

--- a/lib/services/preset_loader.dart
+++ b/lib/services/preset_loader.dart
@@ -6,7 +6,7 @@ class PresetLoader {
   final DatabaseService db;
   PresetLoader(this.db);
 
-  /// JSON format: [{"term":"猫","meaning":"con mèo","level":"N5","note":"neko"}, ...]
+  /// JSON format: [{"term":"猫","hiragana":"ねこ","meaning":"con mèo","level":"N5","note":"neko"}, ...]
   Future<int> importJsonAsset(String path) async {
     final raw = await rootBundle.loadString(path);
     final list = jsonDecode(raw) as List;
@@ -14,6 +14,7 @@ class PresetLoader {
     for (final m in list) {
       await db.addVocab(
         term: m['term'],
+        hiragana: m['hiragana'],
         meaning: m['meaning'],
         level: m['level'],
         note: m['note'],

--- a/lib/services/realm_service.dart
+++ b/lib/services/realm_service.dart
@@ -25,7 +25,7 @@ class RealmService {
       // Khởi tạo SQLite database
       _db = await openDatabase(
         path,
-        version: 1,
+        version: 2,
         onCreate: _createTables,
         onUpgrade: _onUpgrade,
       );
@@ -53,6 +53,7 @@ class RealmService {
       CREATE TABLE vocabs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         term TEXT NOT NULL,
+        hiragana TEXT NOT NULL,
         meaning TEXT NOT NULL,
         level TEXT NOT NULL,
         note TEXT,
@@ -87,6 +88,9 @@ class RealmService {
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
     // Handle database upgrades here if needed
+    if (oldVersion < 2) {
+      await db.execute('ALTER TABLE vocabs ADD COLUMN hiragana TEXT NOT NULL DEFAULT ""');
+    }
   }
 
   bool get isInitialized => _initialized;
@@ -108,6 +112,7 @@ class RealmService {
 
   Future<Vocab?> addVocab({
     required String term,
+    required String hiragana,
     required String meaning,
     required String level,
     String? note,
@@ -117,6 +122,7 @@ class RealmService {
     final now = DateTime.now();
     final vocab = Vocab(
       term: term,
+      hiragana: hiragana,
       meaning: meaning,
       level: level,
       note: note,
@@ -132,6 +138,7 @@ class RealmService {
   Future<void> updateVocab(
     Vocab vocab, {
     String? term,
+    String? hiragana,
     String? meaning,
     String? level,
     String? note,
@@ -140,6 +147,7 @@ class RealmService {
     if (_db == null || vocab.id == null) return;
 
     if (term != null) vocab.term = term;
+    if (hiragana != null) vocab.hiragana = hiragana;
     if (meaning != null) vocab.meaning = meaning;
     if (level != null) vocab.level = level;
     if (note != null) vocab.note = note;

--- a/lib/ui/screens/add_edit_vocab_screen.dart
+++ b/lib/ui/screens/add_edit_vocab_screen.dart
@@ -13,6 +13,7 @@ class AddEditVocabScreen extends StatefulWidget {
 class _State extends State<AddEditVocabScreen> {
   final _formKey = GlobalKey<FormState>();
   String _term = '';
+  String _hiragana = '';
   String _meaning = '';
   String _level = 'N5';
   String? _note;
@@ -23,6 +24,7 @@ class _State extends State<AddEditVocabScreen> {
     super.initState();
     if (widget.vocab != null) {
       _term = widget.vocab!.term;
+      _hiragana = widget.vocab!.hiragana;
       _meaning = widget.vocab!.meaning;
       _level = widget.vocab!.level;
       _note = widget.vocab!.note;
@@ -43,6 +45,12 @@ class _State extends State<AddEditVocabScreen> {
               decoration: const InputDecoration(labelText: 'Từ (kanji/kana)'),
               onSaved: (v) => _term = v!.trim(),
               validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập từ' : null,
+            ),
+            TextFormField(
+              initialValue: _hiragana,
+              decoration: const InputDecoration(labelText: 'Hiragana'),
+              onSaved: (v) => _hiragana = v!.trim(),
+              validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập hiragana' : null,
             ),
             TextFormField(
               initialValue: _meaning,
@@ -87,6 +95,7 @@ class _State extends State<AddEditVocabScreen> {
                       if (widget.vocab == null) {
                         await db.addVocab(
                             term: _term,
+                            hiragana: _hiragana,
                             meaning: _meaning,
                             level: _level,
                             note: _note);
@@ -94,6 +103,7 @@ class _State extends State<AddEditVocabScreen> {
                         await db.updateVocab(
                             widget.vocab!,
                             term: _term,
+                            hiragana: _hiragana,
                             meaning: _meaning,
                             level: _level,
                             note: _note);

--- a/lib/ui/screens/flashcards_screen.dart
+++ b/lib/ui/screens/flashcards_screen.dart
@@ -80,8 +80,20 @@ class _State extends State<FlashcardsScreen> {
                   child: Center(
                     child: AnimatedCrossFade(
                       duration: const Duration(milliseconds: 200),
-                      firstChild: Text(v.term,
-                          style: Theme.of(context).textTheme.displayMedium),
+                      firstChild: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(v.term,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .displayMedium),
+                          const SizedBox(height: 8),
+                          Text(v.hiragana,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .headlineSmall),
+                        ],
+                      ),
                       secondChild: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [

--- a/lib/ui/widgets/vocab_tile.dart
+++ b/lib/ui/widgets/vocab_tile.dart
@@ -9,7 +9,7 @@ class VocabTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(v.term, style: Theme.of(context).textTheme.titleLarge),
-      subtitle: Text(v.meaning),
+      subtitle: Text('${v.hiragana} – ${v.meaning}'),
       trailing: Text(v.level),
       onTap: onTap,
     );

--- a/test/README.md
+++ b/test/README.md
@@ -130,6 +130,7 @@ tearDown(() async {
 ```dart
 final vocab = await TestDatabaseService.addVocab(
   term: '水',
+  hiragana: 'みず',
   meaning: 'nước',
   level: 'N5'
 );

--- a/test/database_integration_test.dart
+++ b/test/database_integration_test.dart
@@ -17,6 +17,7 @@ void main() {
         // Create a vocab
         final vocab = await TestDatabaseService.addVocab(
           term: '猫',
+          hiragana: 'ねこ',
           meaning: 'mèo',
           level: 'N5',
         );
@@ -54,6 +55,7 @@ void main() {
       test('Review logs are deleted with vocab (cascade)', () async {
         final vocab = await TestDatabaseService.addVocab(
           term: '鳥',
+          hiragana: 'とり',
           meaning: 'chim',
           level: 'N4',
         );
@@ -81,11 +83,11 @@ void main() {
     group('Complex Query Tests', () {
       test('Multiple levels and search combinations', () async {
         // Add test data across different levels
-        await TestDatabaseService.addVocab(term: '水', meaning: 'nước', level: 'N5');
-        await TestDatabaseService.addVocab(term: '火', meaning: 'lửa', level: 'N5');
-        await TestDatabaseService.addVocab(term: '図書館', meaning: 'thư viện', level: 'N4');
-        await TestDatabaseService.addVocab(term: '勉強', meaning: 'học tập', level: 'N4');
-        await TestDatabaseService.addVocab(term: '試験', meaning: 'kỳ thi', level: 'N3');
+        await TestDatabaseService.addVocab(term: '水', hiragana: 'みず', meaning: 'nước', level: 'N5');
+        await TestDatabaseService.addVocab(term: '火', hiragana: 'ひ', meaning: 'lửa', level: 'N5');
+        await TestDatabaseService.addVocab(term: '図書館', hiragana: 'としょかん', meaning: 'thư viện', level: 'N4');
+        await TestDatabaseService.addVocab(term: '勉強', hiragana: 'べんきょう', meaning: 'học tập', level: 'N4');
+        await TestDatabaseService.addVocab(term: '試験', hiragana: 'しけん', meaning: 'kỳ thi', level: 'N3');
 
         // Test level filtering
         final n5Vocabs = await TestDatabaseService.getAllVocabs(level: 'N5');
@@ -116,23 +118,23 @@ void main() {
         final futureDay = now.add(const Duration(days: 1));
 
         // Create vocabs with various due dates
-        final vocab1 = await TestDatabaseService.addVocab(term: '今', meaning: 'bây giờ', level: 'N5');
+        final vocab1 = await TestDatabaseService.addVocab(term: '今', hiragana: 'いま', meaning: 'bây giờ', level: 'N5');
         vocab1.dueAt = pastDay; // Very overdue
         await TestDatabaseService.updateVocab(vocab1);
 
-        final vocab2 = await TestDatabaseService.addVocab(term: '昨日', meaning: 'hôm qua', level: 'N5');
+        final vocab2 = await TestDatabaseService.addVocab(term: '昨日', hiragana: 'きのう', meaning: 'hôm qua', level: 'N5');
         vocab2.dueAt = pastHour; // Recently due
         await TestDatabaseService.updateVocab(vocab2);
 
-        final vocab3 = await TestDatabaseService.addVocab(term: '明日', meaning: 'ngày mai', level: 'N5');
+        final vocab3 = await TestDatabaseService.addVocab(term: '明日', hiragana: 'あした', meaning: 'ngày mai', level: 'N5');
         vocab3.dueAt = futureHour; // Due soon
         await TestDatabaseService.updateVocab(vocab3);
 
-        final vocab4 = await TestDatabaseService.addVocab(term: '来週', meaning: 'tuần tới', level: 'N4');
+        final vocab4 = await TestDatabaseService.addVocab(term: '来週', hiragana: 'らいしゅう', meaning: 'tuần tới', level: 'N4');
         vocab4.dueAt = futureDay; // Due later
         await TestDatabaseService.updateVocab(vocab4);
 
-        final vocab5 = await TestDatabaseService.addVocab(term: '新しい', meaning: 'mới', level: 'N5');
+        final vocab5 = await TestDatabaseService.addVocab(term: '新しい', hiragana: 'あたらしい', meaning: 'mới', level: 'N5');
         // vocab5.dueAt remains null (new vocab)
 
         // Get due vocabs
@@ -164,11 +166,11 @@ void main() {
         test('Favorite operations', () async {
           // Create some vocabs
           await TestDatabaseService.addVocab(
-            term: '好き', meaning: 'thích', level: 'N5', favorite: true);
+            term: '好き', hiragana: 'すき', meaning: 'thích', level: 'N5', favorite: true);
           final vocab2 = await TestDatabaseService.addVocab(
-            term: '嫌い', meaning: 'ghét', level: 'N5', favorite: false);
+            term: '嫌い', hiragana: 'きらい', meaning: 'ghét', level: 'N5', favorite: false);
           await TestDatabaseService.addVocab(
-            term: '愛', meaning: 'yêu', level: 'N3', favorite: true);
+            term: '愛', hiragana: 'あい', meaning: 'yêu', level: 'N3', favorite: true);
 
         // Test favorite retrieval
         final favorites = await TestDatabaseService.getFavoriteVocabs();
@@ -206,6 +208,7 @@ void main() {
         for (int i = 0; i < 10; i++) {
           futures.add(TestDatabaseService.addVocab(
             term: '単語$i',
+            hiragana: 'たんご$i',
             meaning: 'từ $i',
             level: 'N${(i % 5) + 1}',
           ));
@@ -241,6 +244,7 @@ void main() {
         for (final entry in vocabs.entries) {
           await TestDatabaseService.addVocab(
             term: entry.key,
+            hiragana: entry.key,
             meaning: entry.value,
             level: 'N5',
           );
@@ -263,12 +267,12 @@ void main() {
       test('Edge cases and error handling', () async {
         // Test with empty/null values
         expect(() async {
-          await TestDatabaseService.addVocab(term: '', meaning: 'test', level: 'N5');
+          await TestDatabaseService.addVocab(term: '', hiragana: '', meaning: 'test', level: 'N5');
         }, throwsA(isA<Exception>()));
 
         // Test update on non-existent vocab
         final fakeVocab = await TestDatabaseService.addVocab(
-          term: 'test', meaning: 'test', level: 'N5');
+          term: 'test', hiragana: 'てすと', meaning: 'test', level: 'N5');
         await TestDatabaseService.deleteVocab(fakeVocab);
         
         // This should not throw but won't update anything
@@ -282,7 +286,7 @@ void main() {
         expect(emptySearch, isA<List>());
 
         // Test search with special characters
-        await TestDatabaseService.addVocab(term: '100%', meaning: '100%', level: 'N5');
+        await TestDatabaseService.addVocab(term: '100%', hiragana: 'ひゃくパーセント', meaning: '100%', level: 'N5');
         final specialSearch = await TestDatabaseService.searchVocabs('100%');
         expect(specialSearch.length, 1);
         expect(specialSearch.first.term, '100%');
@@ -292,8 +296,8 @@ void main() {
     group('Database State Tests', () {
       test('Reset functionality', () async {
         // Add some data
-        await TestDatabaseService.addVocab(term: 'test1', meaning: 'test1', level: 'N5');
-        await TestDatabaseService.addVocab(term: 'test2', meaning: 'test2', level: 'N5');
+        await TestDatabaseService.addVocab(term: 'test1', hiragana: 'てすと1', meaning: 'test1', level: 'N5');
+        await TestDatabaseService.addVocab(term: 'test2', hiragana: 'てすと2', meaning: 'test2', level: 'N5');
         
         final beforeReset = await TestDatabaseService.getTotalVocabCount();
         expect(beforeReset, 2);
@@ -306,7 +310,7 @@ void main() {
         expect(afterReset, 0);
 
         // Verify we can still add data
-        await TestDatabaseService.addVocab(term: 'new', meaning: 'new', level: 'N5');
+        await TestDatabaseService.addVocab(term: 'new', hiragana: 'にゅー', meaning: 'new', level: 'N5');
         final afterAdd = await TestDatabaseService.getTotalVocabCount();
         expect(afterAdd, 1);
       });
@@ -314,7 +318,7 @@ void main() {
       test('Clear all data functionality', () async {
         // Add vocabs and review logs
         final vocab = await TestDatabaseService.addVocab(
-          term: 'test', meaning: 'test', level: 'N5');
+          term: 'test', hiragana: 'てすと', meaning: 'test', level: 'N5');
         await TestDatabaseService.addReviewLog(
           vocab: vocab, grade: 4, nextInterval: 1);
 

--- a/test/database_isolation_test.dart
+++ b/test/database_isolation_test.dart
@@ -15,8 +15,9 @@ void main() {
     test('Tests are isolated from each other - Test 1', () async {
       // Add some data
       await TestDatabaseService.addVocab(
-        term: 'テスト1', 
-        meaning: 'test 1', 
+        term: 'テスト1',
+        hiragana: 'てすと1',
+        meaning: 'test 1',
         level: 'N5'
       );
       
@@ -32,8 +33,9 @@ void main() {
       
       // Add different data
       await TestDatabaseService.addVocab(
-        term: 'テスト2', 
-        meaning: 'test 2', 
+        term: 'テスト2',
+        hiragana: 'てすと2',
+        meaning: 'test 2',
         level: 'N4'
       );
       
@@ -48,8 +50,9 @@ void main() {
       
       // Verify we can still use the database normally
       await TestDatabaseService.addVocab(
-        term: 'テスト3', 
-        meaning: 'test 3', 
+        term: 'テスト3',
+        hiragana: 'てすと3',
+        meaning: 'test 3',
         level: 'N3'
       );
       
@@ -63,8 +66,9 @@ void main() {
     test('In-memory database is truly independent', () async {
       // Create and populate database
       await TestDatabaseService.addVocab(
-        term: '独立', 
-        meaning: 'độc lập', 
+        term: '独立',
+        hiragana: 'どくりつ',
+        meaning: 'độc lập',
         level: 'N2'
       );
       
@@ -75,8 +79,9 @@ void main() {
       
       // Add more data
       await TestDatabaseService.addVocab(
-        term: 'データベース', 
-        meaning: 'database', 
+        term: 'データベース',
+        hiragana: 'でーたべーす',
+        meaning: 'database',
         level: 'N1'
       );
       
@@ -92,8 +97,9 @@ void main() {
     test('Database can handle complex operations in isolation', () async {
       // Add vocab with review logs
       final vocab = await TestDatabaseService.addVocab(
-        term: '複雑', 
-        meaning: 'phức tạp', 
+        term: '複雑',
+        hiragana: 'ふくざつ',
+        meaning: 'phức tạp',
         level: 'N2'
       );
       

--- a/test/database_service_unit_test.dart
+++ b/test/database_service_unit_test.dart
@@ -42,6 +42,7 @@ class DatabaseServiceTest {
       CREATE TABLE vocabs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         term TEXT NOT NULL,
+        hiragana TEXT NOT NULL,
         meaning TEXT NOT NULL,
         level TEXT NOT NULL,
         note TEXT,
@@ -95,6 +96,7 @@ class DatabaseServiceTest {
   /// Insert a new vocab
   static Future<Vocab> insertVocab({
     required String term,
+    String? hiragana,
     required String meaning,
     required String level,
     String? note,
@@ -107,9 +109,10 @@ class DatabaseServiceTest {
   }) async {
     final db = await database;
     final now = DateTime.now();
-    
+
     final vocab = Vocab(
       term: term,
+      hiragana: hiragana ?? term,
       meaning: meaning,
       level: level,
       note: note,

--- a/test/models/vocab_model_test.dart
+++ b/test/models/vocab_model_test.dart
@@ -19,6 +19,7 @@ void main() {
       test('creates Vocab with required fields', () {
         final vocab = Vocab(
           term: '水',
+          hiragana: '水',
           meaning: 'water',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -44,6 +45,7 @@ void main() {
         final vocab = Vocab(
           id: 1,
           term: '火',
+          hiragana: '火',
           meaning: 'fire',
           level: 'N4',
           note: 'test note',
@@ -78,6 +80,7 @@ void main() {
         final vocab = Vocab(
           id: 1,
           term: '山',
+          hiragana: '山',
           meaning: 'mountain',
           level: 'N5',
           note: 'test note',
@@ -111,6 +114,7 @@ void main() {
       test('converts Vocab to Map with null optional fields', () {
         final vocab = Vocab(
           term: '川',
+          hiragana: '川',
           meaning: 'river',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -132,6 +136,7 @@ void main() {
       test('handles boolean to int conversion correctly', () {
         final vocabTrue = Vocab(
           term: 'test',
+          hiragana: 'test',
           meaning: 'test',
           level: 'N5',
           favorite: true,
@@ -141,6 +146,7 @@ void main() {
 
         final vocabFalse = Vocab(
           term: 'test',
+          hiragana: 'test',
           meaning: 'test',
           level: 'N5',
           favorite: false,
@@ -254,6 +260,7 @@ void main() {
         final original = Vocab(
           id: 42,
           term: '本',
+          hiragana: '本',
           meaning: 'book',
           level: 'N5',
           note: 'reading material',
@@ -276,6 +283,7 @@ void main() {
       test('round-trip with minimal fields', () {
         final original = Vocab(
           term: '人',
+          hiragana: '人',
           meaning: 'person',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -293,6 +301,7 @@ void main() {
       test('identical objects are equal', () {
         final vocab = Vocab(
           term: '犬',
+          hiragana: '犬',
           meaning: 'dog',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -307,6 +316,7 @@ void main() {
         final vocab1 = Vocab(
           id: 1,
           term: '猫',
+          hiragana: '猫',
           meaning: 'cat',
           level: 'N5',
           note: 'pet',
@@ -323,6 +333,7 @@ void main() {
         final vocab2 = Vocab(
           id: 1,
           term: '猫',
+          hiragana: '猫',
           meaning: 'cat',
           level: 'N5',
           note: 'pet',
@@ -343,6 +354,7 @@ void main() {
       test('objects with different values are not equal', () {
         final vocab1 = Vocab(
           term: '鳥',
+          hiragana: '鳥',
           meaning: 'bird',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -351,6 +363,7 @@ void main() {
 
         final vocab2 = Vocab(
           term: '鳥',
+          hiragana: '鳥',
           meaning: 'bird',
           level: 'N4', // different level
           createdAt: testCreatedAt,
@@ -363,6 +376,7 @@ void main() {
       test('objects with different types are not equal', () {
         final vocab = Vocab(
           term: '魚',
+          hiragana: '魚',
           meaning: 'fish',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -377,6 +391,7 @@ void main() {
       test('null field differences are detected', () {
         final vocab1 = Vocab(
           term: '車',
+          hiragana: '車',
           meaning: 'car',
           level: 'N5',
           note: 'vehicle',
@@ -386,6 +401,7 @@ void main() {
 
         final vocab2 = Vocab(
           term: '車',
+          hiragana: '車',
           meaning: 'car',
           level: 'N5',
           note: null,
@@ -399,6 +415,7 @@ void main() {
       test('DateTime field differences are detected', () {
         final vocab1 = Vocab(
           term: '家',
+          hiragana: '家',
           meaning: 'house',
           level: 'N5',
           dueAt: testDueAt,
@@ -408,6 +425,7 @@ void main() {
 
         final vocab2 = Vocab(
           term: '家',
+          hiragana: '家',
           meaning: 'house',
           level: 'N5',
           dueAt: testDueAt.add(const Duration(minutes: 1)), // slightly different
@@ -426,6 +444,7 @@ void main() {
         originalVocab = Vocab(
           id: 1,
           term: '学校',
+          hiragana: '学校',
           meaning: 'school',
           level: 'N5',
           note: 'education',
@@ -514,6 +533,7 @@ void main() {
         // Start with a vocab that has some null fields
         final vocabWithNulls = Vocab(
           term: 'test',
+          hiragana: 'test',
           meaning: 'test',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -538,6 +558,7 @@ void main() {
         
         originalVocab.copyWith(
           term: 'modified',
+          hiragana: 'modified',
           meaning: 'modified meaning',
         );
 
@@ -551,6 +572,7 @@ void main() {
         final vocab = Vocab(
           id: 5,
           term: '時間',
+          hiragana: '時間',
           meaning: 'time',
           level: 'N5',
           note: 'temporal concept',
@@ -583,6 +605,7 @@ void main() {
       test('toString handles null fields', () {
         final vocab = Vocab(
           term: '名前',
+          hiragana: '名前',
           meaning: 'name',
           level: 'N5',
           createdAt: testCreatedAt,
@@ -636,6 +659,7 @@ void main() {
         final futureDate = DateTime(2100, 12, 31);
         final vocab = Vocab(
           term: 'future',
+          hiragana: 'future',
           meaning: 'test',
           level: 'N5',
           createdAt: futureDate,
@@ -654,6 +678,7 @@ void main() {
       test('handles edge values for numeric fields', () {
         final vocab = Vocab(
           term: 'edge',
+          hiragana: 'edge',
           meaning: 'test',
           level: 'N5',
           easiness: 0.0,

--- a/test/services/backup_and_streak_test.dart
+++ b/test/services/backup_and_streak_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   test('daily counts and streak', () async {
     final v = await TestDatabaseService.addVocab(
-        term: '猫', meaning: 'mèo', level: 'N5');
+        term: '猫', hiragana: 'ねこ', meaning: 'mèo', level: 'N5');
     final now = DateTime.now();
     await TestDatabaseService.addReviewLog(
         vocab: v, grade: 5, nextInterval: 1, reviewedAt: now);
@@ -33,7 +33,7 @@ void main() {
 
   test('backup and restore', () async {
     final v = await TestDatabaseService.addVocab(
-        term: '犬', meaning: 'chó', level: 'N5');
+        term: '犬', hiragana: 'いぬ', meaning: 'chó', level: 'N5');
     final tempDir = await Directory.systemTemp.createTemp();
     final path = '${tempDir.path}/backup.json';
     await TestDatabaseService.backupToFile(path);

--- a/test/services/srs_service_test.dart
+++ b/test/services/srs_service_test.dart
@@ -274,6 +274,7 @@ void main() {
       test('should reset streak on failure', () async {
         final vocab = await TestDatabaseService.addVocab(
           term: 'test',
+          hiragana: 'てすと',
           meaning: 'test',
           level: 'N5',
         );
@@ -338,6 +339,7 @@ void main() {
       test('should perform complete review cycle', () async {
         final vocab = await TestDatabaseService.addVocab(
           term: 'こんにちは',
+          hiragana: 'こんにちは',
           meaning: 'hello',
           level: 'N5',
         );
@@ -366,6 +368,7 @@ void main() {
       test('should handle multiple consecutive reviews', () async {
         final vocab = await TestDatabaseService.addVocab(
           term: 'test',
+          hiragana: 'てすと',
           meaning: 'test',
           level: 'N5',
         );
@@ -398,6 +401,7 @@ void main() {
       test('should handle review failure and recovery', () async {
         final vocab = await TestDatabaseService.addVocab(
           term: 'difficult',
+          hiragana: 'ディフィカルト',
           meaning: 'muzukashii',
           level: 'N3',
         );
@@ -541,6 +545,7 @@ Vocab _createTestVocab({
   return Vocab(
     id: 1,
     term: 'test',
+    hiragana: 'てすと',
     meaning: 'test',
     level: 'N5',
     repetitions: repetitions,

--- a/test/test_database_helper.dart
+++ b/test/test_database_helper.dart
@@ -38,6 +38,7 @@ class TestDatabaseHelper {
       CREATE TABLE vocabs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         term TEXT NOT NULL,
+        hiragana TEXT NOT NULL,
         meaning TEXT NOT NULL,
         level TEXT NOT NULL,
         note TEXT,
@@ -111,6 +112,7 @@ class TestDatabaseService {
   /// Add a new vocab
   static Future<Vocab> addVocab({
     required String term,
+    required String hiragana,
     required String meaning,
     required String level,
     String? note,
@@ -126,6 +128,7 @@ class TestDatabaseService {
     
     final vocab = Vocab(
       term: term,
+      hiragana: hiragana,
       meaning: meaning,
       level: level,
       note: note,
@@ -259,10 +262,10 @@ class TestDatabaseService {
     final db = await database;
     
     String sql = '''
-      SELECT * FROM vocabs 
-      WHERE (term LIKE ? OR meaning LIKE ?)
+      SELECT * FROM vocabs
+      WHERE (term LIKE ? OR hiragana LIKE ? OR meaning LIKE ?)
     ''';
-    List<dynamic> args = ['%$query%', '%$query%'];
+    List<dynamic> args = ['%$query%', '%$query%', '%$query%'];
 
     if (level != null) {
       sql += ' AND level = ?';

--- a/test/vocab_n5_test.dart
+++ b/test/vocab_n5_test.dart
@@ -14,15 +14,18 @@ void main() {
 
     test('Thêm một số từ N5', () async {
       final words = [
-        {'term': '水', 'meaning': 'nước', 'level': 'N5'},
-        {'term': '火', 'meaning': 'lửa', 'level': 'N5'},
-        {'term': '山', 'meaning': 'núi', 'level': 'N5'},
-        {'term': '川', 'meaning': 'sông', 'level': 'N5'},
-        {'term': '空', 'meaning': 'bầu trời', 'level': 'N5'},
+        {'term': '水', 'hiragana': 'みず', 'meaning': 'nước', 'level': 'N5'},
+        {'term': '火', 'hiragana': 'ひ', 'meaning': 'lửa', 'level': 'N5'},
+        {'term': '山', 'hiragana': 'やま', 'meaning': 'núi', 'level': 'N5'},
+        {'term': '川', 'hiragana': 'かわ', 'meaning': 'sông', 'level': 'N5'},
+        {'term': '空', 'hiragana': 'そら', 'meaning': 'bầu trời', 'level': 'N5'},
       ];
       for (final w in words) {
         final v = await TestDatabaseService.addVocab(
-            term: w['term']!, meaning: w['meaning']!, level: w['level']!);
+            term: w['term']!,
+            hiragana: w['hiragana']!,
+            meaning: w['meaning']!,
+            level: w['level']!);
         expect(v.term, w['term']);
         expect(v.meaning, w['meaning']);
         expect(v.level, w['level']);
@@ -40,11 +43,11 @@ void main() {
     test('Tìm kiếm từ vựng', () async {
       // Add some test data
       await TestDatabaseService.addVocab(
-          term: '本', meaning: 'sách', level: 'N5');
+          term: '本', hiragana: 'ほん', meaning: 'sách', level: 'N5');
       await TestDatabaseService.addVocab(
-          term: '水', meaning: 'nước', level: 'N5');
+          term: '水', hiragana: 'みず', meaning: 'nước', level: 'N5');
       await TestDatabaseService.addVocab(
-          term: '図書館', meaning: 'thư viện', level: 'N4');
+          term: '図書館', hiragana: 'としょかん', meaning: 'thư viện', level: 'N4');
       
       // Search by term
       final searchByTerm = await TestDatabaseService.searchVocabs('本');
@@ -64,7 +67,7 @@ void main() {
     test('Cập nhật và xóa từ vựng', () async {
       // Add a vocab
       final vocab = await TestDatabaseService.addVocab(
-          term: '犬', meaning: 'chó', level: 'N5');
+          term: '犬', hiragana: 'いぬ', meaning: 'chó', level: 'N5');
       
       // Update it
       await TestDatabaseService.updateVocab(
@@ -104,11 +107,11 @@ void main() {
       
       // Add vocabs with different due dates
       final vocab1 = await TestDatabaseService.addVocab(
-          term: '水', meaning: 'nước', level: 'N5');
+          term: '水', hiragana: 'みず', meaning: 'nước', level: 'N5');
       final vocab2 = await TestDatabaseService.addVocab(
-          term: '火', meaning: 'lửa', level: 'N5');
+          term: '火', hiragana: 'ひ', meaning: 'lửa', level: 'N5');
       final vocab3 = await TestDatabaseService.addVocab(
-          term: '山', meaning: 'núi', level: 'N5');
+          term: '山', hiragana: 'やま', meaning: 'núi', level: 'N5');
       
       // Manually set due dates
       vocab1.dueAt = past; // Past due


### PR DESCRIPTION
## Summary
- store hiragana readings alongside vocab terms
- migrate and search vocab table with hiragana support
- display and edit hiragana in UI and presets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6d09ea2c8332b3715635dfafbe0d