### PR TITLE
feat: add quiz question limit

### DIFF
--- a/lib/ui/screens/quiz_screen.dart
+++ b/lib/ui/screens/quiz_screen.dart
@@ -4,7 +4,9 @@ import 'package:get/get.dart';
 import '../../locator.dart';
 import '../../services/database_service.dart';
 import '../../controllers/level_controller.dart';
+import '../../controllers/settings_controller.dart';
 import '../../models/vocab.dart';
+import 'victory_screen.dart';
 
 class QuizScreen extends StatefulWidget {
   const QuizScreen({super.key});
@@ -15,7 +17,9 @@ class QuizScreen extends StatefulWidget {
 class _State extends State<QuizScreen> {
   final DatabaseService db = locator<DatabaseService>();
   final LevelController levelCtrl = Get.find();
+  final SettingsController settings = Get.find();
   late List<Vocab> pool;
+  late int maxQuestions;
   int qIndex = 0;
   int correct = 0;
   List<Vocab> options = [];
@@ -30,7 +34,10 @@ class _State extends State<QuizScreen> {
   void _newQuiz() async {
     final result =
         await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
-    pool = result;
+    result.shuffle();
+    maxQuestions =
+        min(settings.quizLength.value, result.length);
+    pool = result.take(maxQuestions).toList();
     qIndex = 0;
     correct = 0;
     _nextQ();
@@ -38,13 +45,46 @@ class _State extends State<QuizScreen> {
   }
 
   void _nextQ() {
-    if (pool.isEmpty) return;
-    pool.shuffle();
-    current = pool.first;
+    if (qIndex >= maxQuestions) {
+      _finishQuiz();
+      return;
+    }
+    current = pool[qIndex];
     final rng = Random();
     final distractors = List<Vocab>.from(pool)..remove(current);
     distractors.shuffle();
     options = ([current!] + distractors.take(3).toList())..shuffle(rng);
+  }
+
+  void _finishQuiz() {
+    final wrong = maxQuestions - correct;
+    final percent = correct / maxQuestions * 100;
+    if (percent >= 70) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => VictoryScreen(correct: correct, total: maxQuestions),
+        ),
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Kết quả'),
+          content: Text(
+              'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                Navigator.pop(context);
+              },
+              child: const Text('Đóng'),
+            )
+          ],
+        ),
+      );
+    }
   }
 
   @override

--- a/lib/ui/screens/victory_screen.dart
+++ b/lib/ui/screens/victory_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class VictoryScreen extends StatelessWidget {
+  final int correct;
+  final int total;
+
+  const VictoryScreen({super.key, required this.correct, required this.total});
+
+  @override
+  Widget build(BuildContext context) {
+    final wrong = total - correct;
+    final percent = (correct / total * 100).toStringAsFixed(1);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chiến thắng')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.emoji_events, size: 80, color: Colors.amber),
+            const SizedBox(height: 16),
+            Text('Điểm: $correct / $total',
+                style: Theme.of(context).textTheme.headlineSmall),
+            Text('Đúng: $correct'),
+            Text('Sai: $wrong'),
+            Text('Tỉ lệ: $percent%'),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Hoàn thành'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- limit all quiz modes to a configurable number of questions
- show detailed results with score, accuracy, and mistakes
- display a victory screen when scoring above 70%

## Testing
- `flutter test` *(fails: command not found)*
- `curl -L "$FLUTTER_TARBALL_URL" -o /tmp/flutter_install/flutter.tar.xz` *(fails: CONNECT tunnel failed, response 403)*
- `dart format lib/ui/screens/victory_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c7ede03b883328297fe4fab4b6b31