### PR TITLE
Ensure victory screen appears after quiz completion

### DIFF
--- a/lib/ui/screens/fill_in_blank_quiz_screen.dart
+++ b/lib/ui/screens/fill_in_blank_quiz_screen.dart
@@ -32,8 +32,7 @@ class _State extends State<FillInBlankQuizScreen> {
   }
 
   void _newQuiz() async {
-    final result =
-        await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
+    final result = await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
     result.shuffle();
     maxQuestions = min(settings.quizLength.value, result.length);
     pool = result.take(maxQuestions).toList();
@@ -59,7 +58,8 @@ class _State extends State<FillInBlankQuizScreen> {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-            builder: (_) => VictoryScreen(correct: correct, total: maxQuestions)),
+            builder: (_) =>
+                VictoryScreen(correct: correct, total: maxQuestions)),
       );
     } else {
       showDialog(
@@ -121,10 +121,16 @@ class _State extends State<FillInBlankQuizScreen> {
                 if (ok) correct++;
                 ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                     content: Text(ok ? 'Đúng!' : 'Sai: ${current!.meaning}')));
+                final isLast = qIndex + 1 >= maxQuestions;
                 setState(() {
                   qIndex++;
-                  _nextQ();
+                  if (!isLast) {
+                    _nextQ();
+                  }
                 });
+                if (isLast) {
+                  _finishQuiz();
+                }
               },
               child: const Text('Kiểm tra'),
             ),
@@ -136,4 +142,3 @@ class _State extends State<FillInBlankQuizScreen> {
     );
   }
 }
-

--- a/lib/ui/screens/grammar_quiz_screen.dart
+++ b/lib/ui/screens/grammar_quiz_screen.dart
@@ -150,10 +150,16 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
                             Text(ok ? 'Đúng!' : 'Sai: ${current!.meaning}'),
                       ),
                     );
+                    final isLast = qIndex + 1 >= maxQuestions;
                     setState(() {
                       qIndex++;
-                      _nextQ();
+                      if (!isLast) {
+                        _nextQ();
+                      }
                     });
+                    if (isLast) {
+                      _finishQuiz();
+                    }
                   },
                   child: Text(o.meaning),
                 ),
@@ -173,7 +179,8 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-            builder: (_) => VictoryScreen(correct: correct, total: maxQuestions)),
+            builder: (_) =>
+                VictoryScreen(correct: correct, total: maxQuestions)),
       );
     } else {
       showDialog(

--- a/lib/ui/screens/kanji_quiz_screen.dart
+++ b/lib/ui/screens/kanji_quiz_screen.dart
@@ -32,8 +32,7 @@ class _State extends State<KanjiQuizScreen> {
   }
 
   void _newQuiz() async {
-    final result =
-        await db.getAllKanjis(level: levelCtrl.selectedLevel.value);
+    final result = await db.getAllKanjis(level: levelCtrl.selectedLevel.value);
     result.shuffle();
     maxQuestions = min(settings.quizLength.value, result.length);
     pool = result.take(maxQuestions).toList();
@@ -62,7 +61,8 @@ class _State extends State<KanjiQuizScreen> {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-            builder: (_) => VictoryScreen(correct: correct, total: maxQuestions)),
+            builder: (_) =>
+                VictoryScreen(correct: correct, total: maxQuestions)),
       );
     } else {
       showDialog(
@@ -121,10 +121,16 @@ class _State extends State<KanjiQuizScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content:
                             Text(ok ? 'Đúng!' : 'Sai: ${current!.meaning}')));
+                    final isLast = qIndex + 1 >= maxQuestions;
                     setState(() {
                       qIndex++;
-                      _nextQ();
+                      if (!isLast) {
+                        _nextQ();
+                      }
                     });
+                    if (isLast) {
+                      _finishQuiz();
+                    }
                   },
                   child: Text(o.meaning),
                 ),

--- a/lib/ui/screens/matching_quiz_screen.dart
+++ b/lib/ui/screens/matching_quiz_screen.dart
@@ -33,8 +33,7 @@ class _State extends State<MatchingQuizScreen> {
   }
 
   void _newQuiz() async {
-    final result =
-        await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
+    final result = await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
     result.shuffle();
     maxSets = min(settings.quizLength.value, result.length ~/ 3);
     pool = result.take(maxSets * 3).toList();
@@ -70,6 +69,7 @@ class _State extends State<MatchingQuizScreen> {
           correctSets++;
           if (correctSets >= maxSets) {
             _finishQuiz();
+            return;
           } else {
             _nextSet();
           }
@@ -187,4 +187,3 @@ class _State extends State<MatchingQuizScreen> {
     );
   }
 }
-

--- a/lib/ui/screens/quiz_screen.dart
+++ b/lib/ui/screens/quiz_screen.dart
@@ -33,11 +33,9 @@ class _State extends State<QuizScreen> {
   }
 
   void _newQuiz() async {
-    final result =
-        await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
+    final result = await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
     result.shuffle();
-    maxQuestions =
-        min(settings.quizLength.value, result.length);
+    maxQuestions = min(settings.quizLength.value, result.length);
     pool = result.take(maxQuestions).toList();
     qIndex = 0;
     correct = 0;
@@ -124,11 +122,16 @@ class _State extends State<QuizScreen> {
                           if (ok) correct++;
                           setState(() => answerCorrect = ok);
                           Future.delayed(const Duration(seconds: 2), () {
-                            setState(() {
-                              qIndex++;
-                              answerCorrect = null;
-                              _nextQ();
-                            });
+                            final isLast = qIndex + 1 >= maxQuestions;
+                            if (isLast) {
+                              _finishQuiz();
+                            } else {
+                              setState(() {
+                                qIndex++;
+                                answerCorrect = null;
+                                _nextQ();
+                              });
+                            }
                           });
                         }
                       : null,

--- a/lib/ui/screens/true_false_quiz_screen.dart
+++ b/lib/ui/screens/true_false_quiz_screen.dart
@@ -33,8 +33,7 @@ class _State extends State<TrueFalseQuizScreen> {
   }
 
   void _newQuiz() async {
-    final result =
-        await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
+    final result = await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
     result.shuffle();
     maxQuestions = min(settings.quizLength.value, result.length);
     pool = result.take(maxQuestions).toList();
@@ -69,7 +68,8 @@ class _State extends State<TrueFalseQuizScreen> {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-            builder: (_) => VictoryScreen(correct: correct, total: maxQuestions)),
+            builder: (_) =>
+                VictoryScreen(correct: correct, total: maxQuestions)),
       );
     } else {
       showDialog(
@@ -132,10 +132,16 @@ class _State extends State<TrueFalseQuizScreen> {
                 if (ok) correct++;
                 ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(content: Text(ok ? 'Đúng!' : 'Sai')));
+                final isLast = qIndex + 1 >= maxQuestions;
                 setState(() {
                   qIndex++;
-                  _nextQ();
+                  if (!isLast) {
+                    _nextQ();
+                  }
                 });
+                if (isLast) {
+                  _finishQuiz();
+                }
               },
               child: const Text('Đúng'),
             ),
@@ -146,10 +152,16 @@ class _State extends State<TrueFalseQuizScreen> {
                 if (ok) correct++;
                 ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(content: Text(ok ? 'Đúng!' : 'Sai')));
+                final isLast = qIndex + 1 >= maxQuestions;
                 setState(() {
                   qIndex++;
-                  _nextQ();
+                  if (!isLast) {
+                    _nextQ();
+                  }
                 });
+                if (isLast) {
+                  _finishQuiz();
+                }
               },
               child: const Text('Sai'),
             ),
@@ -161,4 +173,3 @@ class _State extends State<TrueFalseQuizScreen> {
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- fix quiz screens to navigate to victory screen after last question
- avoid state updates after finishing quizzes to allow proper back navigation

## Testing
- `flutter test` *(fails: widget tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_689c863c67e48332ad59d9643e46cf78