### PR TITLE
Fix tests for vocab model and widget setup

### DIFF
--- a/test/add_edit_grammar_screen_test.dart
+++ b/test/add_edit_grammar_screen_test.dart
@@ -4,7 +4,8 @@ import 'package:nihongo_flashcard/models/grammar.dart';
 import 'package:nihongo_flashcard/ui/screens/add_edit_grammar_screen.dart';
 
 void main() {
-  testWidgets('AddEditGrammarScreen returns new grammar on save', (tester) async {
+  testWidgets('AddEditGrammarScreen returns new grammar on save',
+      (tester) async {
     Grammar? result;
 
     await tester.pumpWidget(MaterialApp(
@@ -24,12 +25,16 @@ void main() {
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.widgetWithText(TextFormField, 'Tiêu đề'), 'ている');
-    await tester.enterText(find.widgetWithText(TextFormField, 'Nghĩa'), 'đang làm');
-    await tester.enterText(find.widgetWithText(TextFormField, 'Ví dụ'), '本を読んでいる');
-    await tester.enterText(find.widgetWithText(TextFormField, 'Nội dung'), 'content');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Tiêu đề'), 'ている');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Nghĩa'), 'đang làm');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Ví dụ'), '本を読んでいる');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Nội dung'), 'content');
 
-    await tester.tap(find.text('Lưu'));
+    await tester.tap(find.byIcon(Icons.save));
     await tester.pumpAndSettle();
 
     expect(result, isNotNull);
@@ -39,7 +44,8 @@ void main() {
     expect(result!.content, 'content');
   });
 
-  testWidgets('AddEditGrammarScreen prefills data when editing', (tester) async {
+  testWidgets('AddEditGrammarScreen prefills data when editing',
+      (tester) async {
     final grammar = Grammar(
       title: 'は',
       meaning: 'chủ đề',

--- a/test/database_service_unit_test.dart
+++ b/test/database_service_unit_test.dart
@@ -7,7 +7,7 @@ import 'package:nihongo_flashcard/models/vocab.dart';
 /// Unit test version of DatabaseService for testing CRUD operations
 class DatabaseServiceTest {
   static Database? _database;
-  
+
   /// Initialize sqflite_common_ffi for testing (avoiding file I/O)
   static void initializeFfi() {
     if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
@@ -19,9 +19,9 @@ class DatabaseServiceTest {
   /// Get in-memory database instance for unit tests
   static Future<Database> get database async {
     if (_database != null) return _database!;
-    
+
     initializeFfi();
-    
+
     _database = await openDatabase(
       ':memory:', // In-memory database to avoid file I/O
       version: 1,
@@ -31,7 +31,7 @@ class DatabaseServiceTest {
         await db.execute('PRAGMA foreign_keys = ON');
       },
     );
-    
+
     return _database!;
   }
 
@@ -148,7 +148,7 @@ class DatabaseServiceTest {
   /// Read all vocabs
   static Future<List<Vocab>> readAllVocabs({String? level}) async {
     final db = await database;
-    
+
     String sql = 'SELECT * FROM vocabs';
     List<dynamic> args = [];
 
@@ -166,7 +166,7 @@ class DatabaseServiceTest {
   /// Search vocabs by term or meaning
   static Future<List<Vocab>> searchVocabs(String query, {String? level}) async {
     final db = await database;
-    
+
     String sql = '''
       SELECT * FROM vocabs 
       WHERE (term LIKE ? OR meaning LIKE ?)
@@ -219,7 +219,7 @@ class DatabaseServiceTest {
     DateTime? reviewedAt,
   }) async {
     final db = await database;
-    
+
     final log = ReviewLog(
       vocabId: vocabId,
       reviewedAt: reviewedAt ?? DateTime.now(),
@@ -248,7 +248,7 @@ class DatabaseServiceTest {
   /// Count vocabs
   static Future<int> countVocabs({String? level}) async {
     final db = await database;
-    
+
     String sql = 'SELECT COUNT(*) as count FROM vocabs';
     List<dynamic> args = [];
 
@@ -264,7 +264,7 @@ class DatabaseServiceTest {
   /// Count review logs
   static Future<int> countReviewLogs({int? vocabId}) async {
     final db = await database;
-    
+
     String sql = 'SELECT COUNT(*) as count FROM review_logs';
     List<dynamic> args = [];
 
@@ -316,7 +316,7 @@ void main() {
       test('Should insert vocab with all fields', () async {
         final now = DateTime.now();
         final dueDate = now.add(const Duration(days: 1));
-        
+
         final vocab = await DatabaseServiceTest.insertVocab(
           term: '猫',
           meaning: 'cat',
@@ -370,7 +370,8 @@ void main() {
           level: 'N5',
         );
 
-        final readVocab = await DatabaseServiceTest.readVocabById(insertedVocab.id!);
+        final readVocab =
+            await DatabaseServiceTest.readVocabById(insertedVocab.id!);
 
         expect(readVocab, isNotNull);
         expect(readVocab!.id, insertedVocab.id);
@@ -385,9 +386,12 @@ void main() {
       });
 
       test('Should read all vocabs', () async {
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '猫', meaning: 'cat', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '鳥', meaning: 'bird', level: 'N4');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '猫', meaning: 'cat', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '鳥', meaning: 'bird', level: 'N4');
 
         final allVocabs = await DatabaseServiceTest.readAllVocabs();
 
@@ -399,9 +403,12 @@ void main() {
       });
 
       test('Should read vocabs filtered by level', () async {
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '猫', meaning: 'cat', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '図書館', meaning: 'library', level: 'N4');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '猫', meaning: 'cat', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '図書館', meaning: 'library', level: 'N4');
 
         final n5Vocabs = await DatabaseServiceTest.readAllVocabs(level: 'N5');
         final n4Vocabs = await DatabaseServiceTest.readAllVocabs(level: 'N4');
@@ -413,13 +420,13 @@ void main() {
 
       test('Should order vocabs by updatedAt DESC', () async {
         final vocab1 = await DatabaseServiceTest.insertVocab(
-          term: 'first', meaning: 'first', level: 'N5');
-        
+            term: 'first', meaning: 'first', level: 'N5');
+
         // Small delay to ensure different timestamps
         await Future.delayed(const Duration(milliseconds: 10));
-        
+
         final vocab2 = await DatabaseServiceTest.insertVocab(
-          term: 'second', meaning: 'second', level: 'N5');
+            term: 'second', meaning: 'second', level: 'N5');
 
         final allVocabs = await DatabaseServiceTest.readAllVocabs();
 
@@ -431,9 +438,12 @@ void main() {
 
     group('Vocab Search Operations', () {
       test('Should search by term', () async {
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '猫', meaning: 'cat', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '鳥', meaning: 'bird', level: 'N4');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '猫', meaning: 'cat', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '鳥', meaning: 'bird', level: 'N4');
 
         final results = await DatabaseServiceTest.searchVocabs('犬');
 
@@ -442,8 +452,10 @@ void main() {
       });
 
       test('Should search by meaning', () async {
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '猫', meaning: 'cat', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '猫', meaning: 'cat', level: 'N5');
 
         final results = await DatabaseServiceTest.searchVocabs('cat');
 
@@ -452,8 +464,10 @@ void main() {
       });
 
       test('Should search with partial matches', () async {
-        await DatabaseServiceTest.insertVocab(term: '図書館', meaning: 'library', level: 'N4');
-        await DatabaseServiceTest.insertVocab(term: '図書', meaning: 'book', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '図書館', meaning: 'library', level: 'N4');
+        await DatabaseServiceTest.insertVocab(
+            term: '図書', meaning: 'book', level: 'N5');
 
         final results = await DatabaseServiceTest.searchVocabs('図');
 
@@ -464,17 +478,21 @@ void main() {
       });
 
       test('Should search with level filter', () async {
-        await DatabaseServiceTest.insertVocab(term: '水', meaning: 'water', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '海水', meaning: 'seawater', level: 'N3');
+        await DatabaseServiceTest.insertVocab(
+            term: '水', meaning: 'water', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '海水', meaning: 'seawater', level: 'N3');
 
-        final results = await DatabaseServiceTest.searchVocabs('水', level: 'N5');
+        final results =
+            await DatabaseServiceTest.searchVocabs('水', level: 'N5');
 
         expect(results.length, 1);
         expect(results.first.term, '水');
       });
 
       test('Should return empty list for no matches', () async {
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
 
         final results = await DatabaseServiceTest.searchVocabs('xyz');
 
@@ -482,7 +500,8 @@ void main() {
       });
 
       test('Should handle special characters in search', () async {
-        await DatabaseServiceTest.insertVocab(term: '100%', meaning: '100 percent', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '100%', meaning: '100 percent', level: 'N5');
 
         final results = await DatabaseServiceTest.searchVocabs('100%');
 
@@ -500,14 +519,14 @@ void main() {
         );
 
         final originalUpdatedAt = vocab.updatedAt;
-        
+
         // Small delay to ensure different timestamp
         await Future.delayed(const Duration(milliseconds: 10));
 
         vocab.meaning = 'puppy';
         vocab.note = 'Updated meaning';
         vocab.favorite = true;
-        
+
         final updateCount = await DatabaseServiceTest.updateVocab(vocab);
         expect(updateCount, 1);
 
@@ -546,6 +565,7 @@ void main() {
       test('Should throw error when updating vocab without ID', () async {
         final vocab = Vocab(
           term: 'test',
+          hiragana: 'test',
           meaning: 'test',
           level: 'N5',
           createdAt: DateTime.now(),
@@ -680,7 +700,8 @@ void main() {
     });
 
     group('Cascade Delete Operations', () {
-      test('Should delete review logs when vocab is deleted (cascade)', () async {
+      test('Should delete review logs when vocab is deleted (cascade)',
+          () async {
         final vocab = await DatabaseServiceTest.insertVocab(
           term: '魚',
           meaning: 'fish',
@@ -716,11 +737,13 @@ void main() {
         expect(logs.length, 0);
 
         // Verify using count as well
-        final logCount = await DatabaseServiceTest.countReviewLogs(vocabId: vocab.id!);
+        final logCount =
+            await DatabaseServiceTest.countReviewLogs(vocabId: vocab.id!);
         expect(logCount, 0);
       });
 
-      test('Should cascade delete multiple vocabs with their review logs', () async {
+      test('Should cascade delete multiple vocabs with their review logs',
+          () async {
         final vocab1 = await DatabaseServiceTest.insertVocab(
           term: '山',
           meaning: 'mountain',
@@ -770,18 +793,24 @@ void main() {
       test('Should count vocabs correctly', () async {
         expect(await DatabaseServiceTest.countVocabs(), 0);
 
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
         expect(await DatabaseServiceTest.countVocabs(), 1);
 
-        await DatabaseServiceTest.insertVocab(term: '猫', meaning: 'cat', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '図書館', meaning: 'library', level: 'N4');
+        await DatabaseServiceTest.insertVocab(
+            term: '猫', meaning: 'cat', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '図書館', meaning: 'library', level: 'N4');
         expect(await DatabaseServiceTest.countVocabs(), 3);
       });
 
       test('Should count vocabs by level', () async {
-        await DatabaseServiceTest.insertVocab(term: '犬', meaning: 'dog', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '猫', meaning: 'cat', level: 'N5');
-        await DatabaseServiceTest.insertVocab(term: '図書館', meaning: 'library', level: 'N4');
+        await DatabaseServiceTest.insertVocab(
+            term: '犬', meaning: 'dog', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '猫', meaning: 'cat', level: 'N5');
+        await DatabaseServiceTest.insertVocab(
+            term: '図書館', meaning: 'library', level: 'N4');
 
         expect(await DatabaseServiceTest.countVocabs(level: 'N5'), 2);
         expect(await DatabaseServiceTest.countVocabs(level: 'N4'), 1);
@@ -790,24 +819,26 @@ void main() {
 
       test('Should count review logs correctly', () async {
         final vocab1 = await DatabaseServiceTest.insertVocab(
-          term: '犬', meaning: 'dog', level: 'N5');
+            term: '犬', meaning: 'dog', level: 'N5');
         final vocab2 = await DatabaseServiceTest.insertVocab(
-          term: '猫', meaning: 'cat', level: 'N5');
+            term: '猫', meaning: 'cat', level: 'N5');
 
         expect(await DatabaseServiceTest.countReviewLogs(), 0);
 
         await DatabaseServiceTest.insertReviewLog(
-          vocabId: vocab1.id!, grade: 3, intervalAfter: 1);
+            vocabId: vocab1.id!, grade: 3, intervalAfter: 1);
         expect(await DatabaseServiceTest.countReviewLogs(), 1);
 
         await DatabaseServiceTest.insertReviewLog(
-          vocabId: vocab1.id!, grade: 4, intervalAfter: 2);
+            vocabId: vocab1.id!, grade: 4, intervalAfter: 2);
         await DatabaseServiceTest.insertReviewLog(
-          vocabId: vocab2.id!, grade: 5, intervalAfter: 3);
+            vocabId: vocab2.id!, grade: 5, intervalAfter: 3);
         expect(await DatabaseServiceTest.countReviewLogs(), 3);
 
-        expect(await DatabaseServiceTest.countReviewLogs(vocabId: vocab1.id!), 2);
-        expect(await DatabaseServiceTest.countReviewLogs(vocabId: vocab2.id!), 1);
+        expect(
+            await DatabaseServiceTest.countReviewLogs(vocabId: vocab1.id!), 2);
+        expect(
+            await DatabaseServiceTest.countReviewLogs(vocabId: vocab2.id!), 1);
       });
     });
 
@@ -836,7 +867,8 @@ void main() {
         final retrieved = await DatabaseServiceTest.readVocabById(vocab.id!);
         expect(retrieved!.term, '100%の人');
         expect(retrieved.meaning, 'Güter & Bäder');
-        expect(retrieved.note, "It's a test with 'quotes' and \"double quotes\"");
+        expect(
+            retrieved.note, "It's a test with 'quotes' and \"double quotes\"");
       });
 
       test('Should handle large text data', () async {
@@ -859,7 +891,8 @@ void main() {
 
       test('Should handle extreme date values', () async {
         final minDate = DateTime.fromMillisecondsSinceEpoch(0);
-        final maxDate = DateTime.fromMillisecondsSinceEpoch(8640000000000000); // Max JS date
+        final maxDate = DateTime.fromMillisecondsSinceEpoch(
+            8640000000000000); // Max JS date
 
         final vocab = await DatabaseServiceTest.insertVocab(
           term: 'test',
@@ -930,6 +963,7 @@ void main() {
           final vocabCopy = Vocab(
             id: vocab.id,
             term: vocab.term,
+            hiragana: vocab.hiragana,
             meaning: 'updated$i',
             level: vocab.level,
             note: vocab.note,

--- a/test/grammar_list_screen_test.dart
+++ b/test/grammar_list_screen_test.dart
@@ -55,12 +55,11 @@ void main() {
         find.widgetWithText(TextFormField, 'Tiêu đề'), 'テスト');
     await tester.enterText(
         find.widgetWithText(TextFormField, 'Nghĩa'), 'test meaning');
-    await tester.enterText(
-        find.widgetWithText(TextFormField, 'Ví dụ'), '例');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Ví dụ'), '例');
     await tester.enterText(
         find.widgetWithText(TextFormField, 'Nội dung'), 'content');
 
-    await tester.tap(find.text('Lưu'));
+    await tester.tap(find.byIcon(Icons.save));
     await tester.pumpAndSettle();
 
     expect(find.text('テスト'), findsOneWidget);
@@ -87,9 +86,8 @@ void main() {
     await tester.tap(find.text('Sửa'));
     await tester.pumpAndSettle();
 
-    await tester.enterText(
-        find.widgetWithText(TextFormField, 'Tiêu đề'), 'はね');
-    await tester.tap(find.text('Lưu'));
+    await tester.enterText(find.widgetWithText(TextFormField, 'Tiêu đề'), 'はね');
+    await tester.tap(find.byIcon(Icons.save));
     await tester.pumpAndSettle();
 
     expect(find.text('はね'), findsOneWidget);

--- a/test/models/vocab_model_test.dart
+++ b/test/models/vocab_model_test.dart
@@ -104,7 +104,8 @@ void main() {
         expect(map['easiness'], 2.8);
         expect(map['repetitions'], 3);
         expect(map['intervalDays'], 7);
-        expect(map['lastReviewedAt'], testLastReviewedAt.millisecondsSinceEpoch);
+        expect(
+            map['lastReviewedAt'], testLastReviewedAt.millisecondsSinceEpoch);
         expect(map['dueAt'], testDueAt.millisecondsSinceEpoch);
         expect(map['favorite'], 1); // boolean converted to int
         expect(map['createdAt'], testCreatedAt.millisecondsSinceEpoch);
@@ -428,7 +429,8 @@ void main() {
           hiragana: '家',
           meaning: 'house',
           level: 'N5',
-          dueAt: testDueAt.add(const Duration(minutes: 1)), // slightly different
+          dueAt:
+              testDueAt.add(const Duration(minutes: 1)), // slightly different
           createdAt: testCreatedAt,
           updatedAt: testUpdatedAt,
         );
@@ -467,7 +469,7 @@ void main() {
 
       test('copyWith single field change', () {
         final copy = originalVocab.copyWith(meaning: 'educational institution');
-        
+
         expect(copy.id, originalVocab.id);
         expect(copy.term, originalVocab.term);
         expect(copy.meaning, 'educational institution'); // changed
@@ -486,7 +488,7 @@ void main() {
       test('copyWith multiple field changes', () {
         final newDueAt = DateTime(2024, 2, 1);
         final newUpdatedAt = DateTime(2024, 1, 15);
-        
+
         final copy = originalVocab.copyWith(
           level: 'N4',
           favorite: true,
@@ -500,7 +502,7 @@ void main() {
         expect(copy.easiness, 3.0);
         expect(copy.dueAt, newDueAt);
         expect(copy.updatedAt, newUpdatedAt);
-        
+
         // Unchanged fields
         expect(copy.id, originalVocab.id);
         expect(copy.term, originalVocab.term);
@@ -517,7 +519,8 @@ void main() {
         // so passing null doesn't override fields to null, it preserves original values
         final copy = originalVocab.copyWith(
           id: null, // This won't set id to null, it will keep originalVocab.id
-          note: null, // This won't set note to null, it will keep originalVocab.note
+          note:
+              null, // This won't set note to null, it will keep originalVocab.note
           lastReviewedAt: null,
           dueAt: null,
         );
@@ -528,7 +531,7 @@ void main() {
         expect(copy.lastReviewedAt, originalVocab.lastReviewedAt);
         expect(copy.dueAt, originalVocab.dueAt);
       });
-      
+
       test('copyWith can override non-null fields to different values', () {
         // Start with a vocab that has some null fields
         final vocabWithNulls = Vocab(
@@ -540,12 +543,12 @@ void main() {
           updatedAt: testUpdatedAt,
           // id, note, lastReviewedAt, dueAt are null by default
         );
-        
+
         final copy = vocabWithNulls.copyWith(
           id: 42,
           note: 'new note',
         );
-        
+
         expect(copy.id, 42);
         expect(copy.note, 'new note');
         expect(copy.lastReviewedAt, isNull); // still null
@@ -555,7 +558,7 @@ void main() {
       test('copyWith preserves original object', () {
         final originalTerm = originalVocab.term;
         final originalMeaning = originalVocab.meaning;
-        
+
         originalVocab.copyWith(
           term: 'modified',
           hiragana: 'modified',
@@ -699,6 +702,7 @@ void main() {
       test('handles empty and special strings', () {
         final vocab = Vocab(
           term: '', // empty string
+          hiragana: '',
           meaning: '   ', // whitespace
           level: '🎌', // emoji
           note: 'Line 1\nLine 2\tTab', // special characters

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,14 +7,33 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
-
 import 'package:nihongo_flashcard/app.dart';
+import 'package:nihongo_flashcard/locator.dart';
+import 'package:nihongo_flashcard/services/database_service.dart';
+import 'package:nihongo_flashcard/models/vocab.dart';
+import 'package:nihongo_flashcard/models/kanji.dart';
 import 'test_database_helper.dart';
+
+class FakeDatabaseService extends DatabaseService {
+  @override
+  bool get isInitialized => true;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<List<Vocab>> getAllVocabs({String? level}) async => [];
+
+  @override
+  Future<List<Kanji>> getAllKanjis({String? level}) async => [];
+}
 
 void main() {
   group('Widget Tests', () {
     setUp(() async {
-      // Initialize test database before each test
+      await locator.reset();
+      locator.registerSingleton<DatabaseService>(FakeDatabaseService());
+      // Initialize test database before each test (unused but keeps DB logic)
       await TestDatabaseService.initialize();
       await TestDatabaseService.reset();
     });
@@ -22,34 +41,35 @@ void main() {
     tearDown(() async {
       // Clean up after each test
       await TestDatabaseService.reset();
+      await locator.reset();
     });
 
     testWidgets('App launches without crashing', (WidgetTester tester) async {
       // Build our app and trigger a frame.
-        await tester.pumpWidget(
-          const NihongoApp(),
-        );
+      await tester.pumpWidget(
+        const NihongoApp(),
+      );
 
-        // Just verify that the app launches
-        expect(find.byType(GetMaterialApp), findsOneWidget);
+      // Just verify that the app launches
+      expect(find.byType(GetMaterialApp), findsOneWidget);
     });
 
     testWidgets('App can be built multiple times', (WidgetTester tester) async {
       // Test that we can rebuild the app without issues
       // (this verifies our database isolation works)
-      
-        await tester.pumpWidget(
-          const NihongoApp(),
-        );
 
-        expect(find.byType(GetMaterialApp), findsOneWidget);
+      await tester.pumpWidget(
+        const NihongoApp(),
+      );
 
-        // Rebuild
-        await tester.pumpWidget(
-          const NihongoApp(),
-        );
+      expect(find.byType(GetMaterialApp), findsOneWidget);
 
-        expect(find.byType(GetMaterialApp), findsOneWidget);
+      // Rebuild
+      await tester.pumpWidget(
+        const NihongoApp(),
+      );
+
+      expect(find.byType(GetMaterialApp), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- update tests to include required `hiragana` field for `Vocab`
- add `FakeDatabaseService` registration for widget tests
- adjust grammar screen tests to tap save icon

## Testing
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c8555768c83328797c2a2c6c7dddb