### PR TITLE
Fix quiz completion navigation using GoRouter

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -16,6 +16,7 @@ import 'ui/screens/grammar_quiz_screen.dart';
 import 'ui/screens/grammar_detail_screen.dart';
 import 'ui/screens/add_edit_grammar_screen.dart';
 import 'ui/screens/stats_screen.dart';
+import 'ui/screens/victory_screen.dart';
 
 final router = GoRouter(routes: [
   GoRoute(path: '/', builder: (_, __) => const MainScreen()),
@@ -56,4 +57,11 @@ final router = GoRouter(routes: [
     },
   ),
   GoRoute(path: '/stats', builder: (_, __) => StatsScreen()),
+  GoRoute(
+    path: '/victory',
+    builder: (context, state) {
+      final data = state.extra as Map<String, int>;
+      return VictoryScreen(correct: data['correct']!, total: data['total']!);
+    },
+  ),
 ]);

--- a/lib/ui/screens/fill_in_blank_quiz_screen.dart
+++ b/lib/ui/screens/fill_in_blank_quiz_screen.dart
@@ -6,7 +6,7 @@ import '../../services/database_service.dart';
 import '../../controllers/level_controller.dart';
 import '../../controllers/settings_controller.dart';
 import '../../models/vocab.dart';
-import 'victory_screen.dart';
+import 'package:go_router/go_router.dart';
 
 class FillInBlankQuizScreen extends StatefulWidget {
   const FillInBlankQuizScreen({super.key});
@@ -54,33 +54,29 @@ class _State extends State<FillInBlankQuizScreen> {
   void _finishQuiz() {
     final wrong = maxQuestions - correct;
     final percent = correct / maxQuestions * 100;
-    if (percent >= 70) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-            builder: (_) =>
-                VictoryScreen(correct: correct, total: maxQuestions)),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Kết quả'),
-          content: Text(
-              'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
-              },
-              child: const Text('Đóng'),
-            )
-          ],
-        ),
-      );
+      if (percent >= 70) {
+        context.go('/victory',
+            extra: {'correct': correct, 'total': maxQuestions});
+      } else {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Kết quả'),
+            content: Text(
+                'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+                child: const Text('Đóng'),
+              )
+            ],
+          ),
+        );
+      }
     }
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/grammar_quiz_screen.dart
+++ b/lib/ui/screens/grammar_quiz_screen.dart
@@ -7,7 +7,7 @@ import 'package:get/get.dart';
 
 import '../../controllers/settings_controller.dart';
 import '../../models/grammar.dart';
-import 'victory_screen.dart';
+import 'package:go_router/go_router.dart';
 
 class GrammarQuizScreen extends StatefulWidget {
   const GrammarQuizScreen({super.key});
@@ -175,31 +175,27 @@ class _GrammarQuizScreenState extends State<GrammarQuizScreen> {
   void _finishQuiz() {
     final wrong = maxQuestions - correct;
     final percent = correct / maxQuestions * 100;
-    if (percent >= 70) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-            builder: (_) =>
-                VictoryScreen(correct: correct, total: maxQuestions)),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Kết quả'),
-          content: Text(
-              'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
-              },
-              child: const Text('Đóng'),
-            )
-          ],
-        ),
-      );
+      if (percent >= 70) {
+        context.go('/victory',
+            extra: {'correct': correct, 'total': maxQuestions});
+      } else {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Kết quả'),
+            content: Text(
+                'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+                child: const Text('Đóng'),
+              )
+            ],
+          ),
+        );
+      }
     }
-  }
 }

--- a/lib/ui/screens/kanji_quiz_screen.dart
+++ b/lib/ui/screens/kanji_quiz_screen.dart
@@ -6,7 +6,7 @@ import '../../services/database_service.dart';
 import '../../controllers/level_controller.dart';
 import '../../controllers/settings_controller.dart';
 import '../../models/kanji.dart';
-import 'victory_screen.dart';
+import 'package:go_router/go_router.dart';
 
 class KanjiQuizScreen extends StatefulWidget {
   const KanjiQuizScreen({super.key});
@@ -57,33 +57,29 @@ class _State extends State<KanjiQuizScreen> {
   void _finishQuiz() {
     final wrong = maxQuestions - correct;
     final percent = correct / maxQuestions * 100;
-    if (percent >= 70) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-            builder: (_) =>
-                VictoryScreen(correct: correct, total: maxQuestions)),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Kết quả'),
-          content: Text(
-              'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
-              },
-              child: const Text('Đóng'),
-            )
-          ],
-        ),
-      );
+      if (percent >= 70) {
+        context.go('/victory',
+            extra: {'correct': correct, 'total': maxQuestions});
+      } else {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Kết quả'),
+            content: Text(
+                'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+                child: const Text('Đóng'),
+              )
+            ],
+          ),
+        );
+      }
     }
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/matching_quiz_screen.dart
+++ b/lib/ui/screens/matching_quiz_screen.dart
@@ -6,7 +6,7 @@ import '../../services/database_service.dart';
 import '../../controllers/level_controller.dart';
 import '../../controllers/settings_controller.dart';
 import '../../models/vocab.dart';
-import 'victory_screen.dart';
+import 'package:go_router/go_router.dart';
 
 class MatchingQuizScreen extends StatefulWidget {
   const MatchingQuizScreen({super.key});
@@ -87,33 +87,29 @@ class _State extends State<MatchingQuizScreen> {
   void _finishQuiz() {
     final wrong = maxSets - correctSets;
     final percent = correctSets / maxSets * 100;
-    if (percent >= 70) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-            builder: (_) =>
-                VictoryScreen(correct: correctSets, total: maxSets)),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Kết quả'),
-          content: Text(
-              'Điểm: $correctSets/$maxSets\nĐúng: $correctSets\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
-              },
-              child: const Text('Đóng'),
-            )
-          ],
-        ),
-      );
+      if (percent >= 70) {
+        context.go('/victory',
+            extra: {'correct': correctSets, 'total': maxSets});
+      } else {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Kết quả'),
+            content: Text(
+                'Điểm: $correctSets/$maxSets\nĐúng: $correctSets\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+                child: const Text('Đóng'),
+              )
+            ],
+          ),
+        );
+      }
     }
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/quiz_screen.dart
+++ b/lib/ui/screens/quiz_screen.dart
@@ -6,7 +6,7 @@ import '../../services/database_service.dart';
 import '../../controllers/level_controller.dart';
 import '../../controllers/settings_controller.dart';
 import '../../models/vocab.dart';
-import 'victory_screen.dart';
+import 'package:go_router/go_router.dart';
 
 class QuizScreen extends StatefulWidget {
   const QuizScreen({super.key});
@@ -58,33 +58,29 @@ class _State extends State<QuizScreen> {
   void _finishQuiz() {
     final wrong = maxQuestions - correct;
     final percent = correct / maxQuestions * 100;
-    if (percent >= 70) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (_) => VictoryScreen(correct: correct, total: maxQuestions),
-        ),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Kết quả'),
-          content: Text(
-              'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
-              },
-              child: const Text('Đóng'),
-            )
-          ],
-        ),
-      );
+      if (percent >= 70) {
+        context.go('/victory',
+            extra: {'correct': correct, 'total': maxQuestions});
+      } else {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Kết quả'),
+            content: Text(
+                'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+                child: const Text('Đóng'),
+              )
+            ],
+          ),
+        );
+      }
     }
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/true_false_quiz_screen.dart
+++ b/lib/ui/screens/true_false_quiz_screen.dart
@@ -6,7 +6,7 @@ import '../../services/database_service.dart';
 import '../../controllers/level_controller.dart';
 import '../../controllers/settings_controller.dart';
 import '../../models/vocab.dart';
-import 'victory_screen.dart';
+import 'package:go_router/go_router.dart';
 
 class TrueFalseQuizScreen extends StatefulWidget {
   const TrueFalseQuizScreen({super.key});
@@ -64,33 +64,29 @@ class _State extends State<TrueFalseQuizScreen> {
   void _finishQuiz() {
     final wrong = maxQuestions - correct;
     final percent = correct / maxQuestions * 100;
-    if (percent >= 70) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-            builder: (_) =>
-                VictoryScreen(correct: correct, total: maxQuestions)),
-      );
-    } else {
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Kết quả'),
-          content: Text(
-              'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pop(context);
-              },
-              child: const Text('Đóng'),
-            )
-          ],
-        ),
-      );
+      if (percent >= 70) {
+        context.go('/victory',
+            extra: {'correct': correct, 'total': maxQuestions});
+      } else {
+        showDialog(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Kết quả'),
+            content: Text(
+                'Điểm: $correct/$maxQuestions\nĐúng: $correct\nSai: $wrong\nTỉ lệ: ${percent.toStringAsFixed(1)}%'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+                child: const Text('Đóng'),
+              )
+            ],
+          ),
+        );
+      }
     }
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/victory_screen.dart
+++ b/lib/ui/screens/victory_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class VictoryScreen extends StatelessWidget {
   final int correct;
@@ -24,10 +25,10 @@ class VictoryScreen extends StatelessWidget {
             Text('Sai: $wrong'),
             Text('Tỉ lệ: $percent%'),
             const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Hoàn thành'),
-            )
+              ElevatedButton(
+                onPressed: () => context.go('/'),
+                child: const Text('Hoàn thành'),
+              )
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add victory route to GoRouter and handle quiz completion with context.go
- replace Navigator.pushReplacement with GoRouter navigation across quiz screens
- wire victory screen and failures to return to home via GoRouter

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c89cbf7b083329655944d6c27bf8c