### PR TITLE
feat: add time attack quiz mode

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -9,6 +9,7 @@ import 'ui/screens/quiz_screen.dart';
 import 'ui/screens/true_false_quiz_screen.dart';
 import 'ui/screens/fill_in_blank_quiz_screen.dart';
 import 'ui/screens/matching_quiz_screen.dart';
+import 'ui/screens/time_attack_quiz_screen.dart';
 import 'ui/screens/kanji_flashcards_screen.dart';
 import 'ui/screens/kanji_quiz_screen.dart';
 import 'ui/screens/add_edit_kanji_screen.dart';
@@ -32,6 +33,7 @@ final router = GoRouter(routes: [
   GoRoute(path: '/quiz-tf', builder: (_, __) => const TrueFalseQuizScreen()),
   GoRoute(path: '/quiz-fill', builder: (_, __) => const FillInBlankQuizScreen()),
   GoRoute(path: '/quiz-match', builder: (_, __) => const MatchingQuizScreen()),
+  GoRoute(path: '/quiz-time', builder: (_, __) => const TimeAttackQuizScreen()),
   GoRoute(
     path: '/kanji-add',
     builder: (context, state) {

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -144,6 +144,10 @@ class HomeScreen extends StatelessWidget {
                       icon: Icons.link,
                       label: 'Matching',
                       onTap: () => _selectLevel(context, '/quiz-match')),
+                  _QuickBtn(
+                      icon: Icons.timer,
+                      label: 'Time Attack',
+                      onTap: () => _selectLevel(context, '/quiz-time')),
                 ],
               ),
 

--- a/lib/ui/screens/time_attack_quiz_screen.dart
+++ b/lib/ui/screens/time_attack_quiz_screen.dart
@@ -21,7 +21,8 @@ class _State extends State<TimeAttackQuizScreen> {
   Vocab? current;
   List<Vocab> options = [];
   int correct = 0;
-  int total = 0;
+  int answered = 0;
+  int index = 0;
   int remaining = 60;
   Timer? timer;
 
@@ -49,11 +50,11 @@ class _State extends State<TimeAttackQuizScreen> {
 
   void _nextQ() {
     if (pool.isEmpty) return;
-    if (total >= pool.length) {
+    if (index >= pool.length) {
       pool.shuffle();
-      total = 0;
+      index = 0;
     }
-    current = pool[total];
+    current = pool[index];
     final rng = Random();
     final distractors = List<Vocab>.from(pool)..remove(current);
     distractors.shuffle();
@@ -62,14 +63,19 @@ class _State extends State<TimeAttackQuizScreen> {
 
   void _answer(Vocab selected) {
     if (selected.id == current!.id) correct++;
-    total++;
+    answered++;
+    index++;
     _nextQ();
     setState(() {});
   }
 
   void _finishQuiz() {
     timer?.cancel();
-    context.go('/victory', extra: {'correct': correct, 'total': total});
+    if (answered == 0) {
+      context.pop();
+      return;
+    }
+    context.go('/victory', extra: {'correct': correct, 'total': answered});
   }
 
   @override
@@ -120,4 +126,3 @@ class _State extends State<TimeAttackQuizScreen> {
     super.dispose();
   }
 }
-

--- a/lib/ui/screens/time_attack_quiz_screen.dart
+++ b/lib/ui/screens/time_attack_quiz_screen.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../locator.dart';
+import '../../services/database_service.dart';
+import '../../controllers/level_controller.dart';
+import '../../models/vocab.dart';
+import 'package:go_router/go_router.dart';
+
+class TimeAttackQuizScreen extends StatefulWidget {
+  const TimeAttackQuizScreen({super.key});
+  @override
+  State<TimeAttackQuizScreen> createState() => _State();
+}
+
+class _State extends State<TimeAttackQuizScreen> {
+  final DatabaseService db = locator<DatabaseService>();
+  final LevelController levelCtrl = Get.find();
+  List<Vocab> pool = [];
+  Vocab? current;
+  List<Vocab> options = [];
+  int correct = 0;
+  int total = 0;
+  int remaining = 60;
+  Timer? timer;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_start);
+  }
+
+  Future<void> _start() async {
+    final result = await db.getAllVocabs(level: levelCtrl.selectedLevel.value);
+    if (result.isEmpty) return;
+    pool = result..shuffle();
+    _nextQ();
+    timer = Timer.periodic(const Duration(seconds: 1), (t) {
+      if (remaining <= 1) {
+        t.cancel();
+        _finishQuiz();
+      } else {
+        setState(() => remaining--);
+      }
+    });
+    setState(() {});
+  }
+
+  void _nextQ() {
+    if (pool.isEmpty) return;
+    if (total >= pool.length) {
+      pool.shuffle();
+      total = 0;
+    }
+    current = pool[total];
+    final rng = Random();
+    final distractors = List<Vocab>.from(pool)..remove(current);
+    distractors.shuffle();
+    options = ([current!] + distractors.take(3).toList())..shuffle(rng);
+  }
+
+  void _answer(Vocab selected) {
+    if (selected.id == current!.id) correct++;
+    total++;
+    _nextQ();
+    setState(() {});
+  }
+
+  void _finishQuiz() {
+    timer?.cancel();
+    context.go('/victory', extra: {'correct': correct, 'total': total});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (current == null || options.isEmpty) {
+      return Scaffold(
+          appBar: AppBar(title: const Text('Time Attack')),
+          body: const Center(child: Text('Chưa đủ dữ liệu.')));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Time Attack')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Thời gian: $remaining',
+                style: Theme.of(context).textTheme.titleLarge),
+            const SizedBox(height: 8),
+            Card(
+                child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Text(current!.term,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.displaySmall),
+            )),
+            const SizedBox(height: 16),
+            for (final o in options)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: ElevatedButton(
+                  onPressed: () => _answer(o),
+                  child: Text(o.meaning),
+                ),
+              ),
+            const Spacer(),
+            Text('Đúng: $correct', textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    timer?.cancel();
+    super.dispose();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Time Attack quiz screen with countdown-based challenge
- expose Time Attack quick-start option on home screen
- register route for Time Attack quiz

## Testing
- `./test_app.sh` (fails: Flutter is not installed)

------
https://chatgpt.com/codex/tasks/task_e_68c4f76885048332bb05a40c66367419